### PR TITLE
[WIP] Add all core XPO business object definitions

### DIFF
--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/BillOfMaterials.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/BillOfMaterials.cs
@@ -1,0 +1,73 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("İmalat Yönetimi")]
+    [DisplayName("Ürün Ağacı (Reçete, XPO)")]
+    public class BillOfMaterials : XPObject
+    {
+        public BillOfMaterials(Session session) : base(session) { }
+
+        private string _bomCode;
+        [Size(50)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Ürün Ağacı Kodu")]
+        public string BomCode
+        {
+            get => _bomCode;
+            set => SetPropertyValue(nameof(BomCode), ref _bomCode, value);
+        }
+
+        private Material _product;
+        [Association("Material-BillOfMaterialsProduct")]
+        [XafDisplayName("Üretilecek Ürün/Mamul")]
+        public Material Product
+        {
+            get => _product;
+            set {
+                if (SetPropertyValue(nameof(Product), ref _product, value))
+                {
+                    if(!IsLoading && Product != null)
+                    {
+                        // Ürün seçildiğinde birimini otomatik çekebiliriz
+                        Unit = Product.BaseUnit;
+                    }
+                }
+            }
+        }
+
+        private string _description;
+        [XafDisplayName("Açıklama")]
+        public string Description { get => _description; set => SetPropertyValue(nameof(Description), ref _description, value); }
+
+        private double _quantity;
+        [XafDisplayName("Üretim Miktarı (Bu reçete kaç adet ürün için)")]
+        public double Quantity { get => _quantity; set => SetPropertyValue(nameof(Quantity), ref _quantity, value); }
+
+        private string _unit;
+        [XafDisplayName("Birim")]
+        public string Unit { get => _unit; set => SetPropertyValue(nameof(Unit), ref _unit, value); }
+
+        private string _version;
+        [XafDisplayName("Versiyon")]
+        public string Version { get => _version; set => SetPropertyValue(nameof(Version), ref _version, value); }
+
+        private bool _isActive;
+        [XafDisplayName("Aktif Reçete")]
+        public bool IsActive { get => _isActive; set => SetPropertyValue(nameof(IsActive), ref _isActive, value); }
+
+        [Association("BOM-BomItems"), Aggregated]
+        [XafDisplayName("Reçete Malzemeleri")]
+        public XPCollection<BomItem> BomItems => GetCollection<BomItem>(nameof(BomItems));
+
+        [Association("BillOfMaterials-ProductionOrders")]
+        [XafDisplayName("Kullanıldığı Üretim Emirleri")]
+        public XPCollection<ProductionOrder> ProductionOrders => GetCollection<ProductionOrder>(nameof(ProductionOrders));
+
+        public override void AfterConstruction() { base.AfterConstruction(); Quantity = 1; IsActive = true; Version = "1.0"; }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/BomItem.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/BomItem.cs
@@ -1,0 +1,62 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DisplayName("Ürün Ağacı Kalemi (XPO)")]
+    public class BomItem : XPObject
+    {
+        public BomItem(Session session) : base(session) { }
+
+        private BillOfMaterials _billOfMaterials;
+        [Association("BOM-BomItems")]
+        [Browsable(false)]
+        public BillOfMaterials BillOfMaterials
+        {
+            get => _billOfMaterials;
+            set => SetPropertyValue(nameof(BillOfMaterials), ref _billOfMaterials, value);
+        }
+
+        private Material _material;
+        [Association("Material-BomItems")]
+        [XafDisplayName("Malzeme/Yarı Mamul")]
+        public Material Material
+        {
+            get => _material;
+            set {
+                if(SetPropertyValue(nameof(Material), ref _material, value))
+                {
+                    if(!IsLoading && Material != null)
+                    {
+                        // Malzeme seçildiğinde birimini otomatik çekebiliriz
+                        Unit = Material.BaseUnit;
+                    }
+                }
+            }
+        }
+
+        private double _quantity;
+        [XafDisplayName("Miktar")]
+        public double Quantity { get => _quantity; set => SetPropertyValue(nameof(Quantity), ref _quantity, value); }
+
+        private string _unit;
+        [XafDisplayName("Birim")]
+        public string Unit { get => _unit; set => SetPropertyValue(nameof(Unit), ref _unit, value); }
+
+        private double _scrapPercentage;
+        [XafDisplayName("Fire Oranı (%)")]
+        public double ScrapPercentage { get => _scrapPercentage; set => SetPropertyValue(nameof(ScrapPercentage), ref _scrapPercentage, value); }
+
+        private string _notes;
+        [XafDisplayName("Notlar")]
+        public string Notes { get => _notes; set => SetPropertyValue(nameof(Notes), ref _notes, value); }
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            Quantity = 1;
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Customer.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Customer.cs
@@ -1,0 +1,112 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+// using DevExpress.Persistent.Validation; // Validation modülü eklenince aktifleşir
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Müşteri Yönetimi")]
+    [DisplayName("Müşteri (XPO)")]
+    public class Customer : XPObject
+    {
+        public Customer(Session session) : base(session) { }
+
+        private string _customerCode;
+        [Size(20)]
+        // [RuleRequiredField("RuleRequiredField for Customer.CustomerCode", DefaultContexts.Save)]
+        // [RuleUniqueValue("CustomerCode_IsUnique_XPO", DefaultContexts.Save)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Müşteri Kodu"), ToolTip("Müşteri kodunu giriniz")]
+        public string CustomerCode
+        {
+            get => _customerCode;
+            set => SetPropertyValue(nameof(CustomerCode), ref _customerCode, value);
+        }
+
+        private string _companyName;
+        [Size(255)]
+        // [RuleRequiredField("RuleRequiredField for Customer.CompanyName", DefaultContexts.Save)]
+        [XafDisplayName("Firma Adı"), ToolTip("Firma adını giriniz")]
+        public string CompanyName
+        {
+            get => _companyName;
+            set => SetPropertyValue(nameof(CompanyName), ref _companyName, value);
+        }
+
+        private string _contactPerson;
+        [Size(100)]
+        [XafDisplayName("Yetkili Kişi")]
+        public string ContactPerson
+        {
+            get => _contactPerson;
+            set => SetPropertyValue(nameof(ContactPerson), ref _contactPerson, value);
+        }
+
+        private string _phoneNumber;
+        [Size(20)]
+        [XafDisplayName("Telefon")]
+        public string PhoneNumber
+        {
+            get => _phoneNumber;
+            set => SetPropertyValue(nameof(PhoneNumber), ref _phoneNumber, value);
+        }
+
+        private string _email;
+        [Size(100)]
+        [XafDisplayName("E-posta")]
+        public string Email
+        {
+            get => _email;
+            set => SetPropertyValue(nameof(Email), ref _email, value);
+        }
+
+        private string _address;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Adres")]
+        public string Address
+        {
+            get => _address;
+            set => SetPropertyValue(nameof(Address), ref _address, value);
+        }
+
+        [Association("Customer-Leads")]
+        [XafDisplayName("Potansiyel Müşterileri (Bu Müşteriye Dönüşenler)")]
+        public XPCollection<Lead> ConvertedLeads => GetCollection<Lead>(nameof(ConvertedLeads));
+
+        [Association("Customer-SalesOpportunities")]
+        [XafDisplayName("Satış Fırsatları")]
+        public XPCollection<SalesOpportunity> SalesOpportunities => GetCollection<SalesOpportunity>(nameof(SalesOpportunities));
+
+        [Association("Customer-Offers")]
+        [XafDisplayName("Teklifler")]
+        public XPCollection<Offer> Offers => GetCollection<Offer>(nameof(Offers));
+
+        [Association("Customer-Shipments")]
+        [XafDisplayName("Sevkiyatlar")]
+        public XPCollection<Shipment> Shipments => GetCollection<Shipment>(nameof(Shipments));
+
+        [Association("Customer-Invoices")]
+        [XafDisplayName("Faturalar")]
+        public XPCollection<Invoice> Invoices => GetCollection<Invoice>(nameof(Invoices));
+
+        [Association("Customer-Equipments")]
+        [XafDisplayName("Ekipmanları")]
+        public XPCollection<Equipment> Equipments => GetCollection<Equipment>(nameof(Equipments));
+
+        [Association("Customer-ServiceTickets")]
+        [XafDisplayName("Servis Talepleri")]
+        public XPCollection<ServiceTicket> ServiceTickets => GetCollection<ServiceTicket>(nameof(ServiceTickets));
+
+        [Association("Customer-ServiceContracts")]
+        [XafDisplayName("Hizmet Sözleşmeleri")]
+        public XPCollection<ServiceContract> ServiceContracts => GetCollection<ServiceContract>(nameof(ServiceContracts));
+
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Employee.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Employee.cs
@@ -1,0 +1,142 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using DevExpress.Persistent.BaseImpl.Xpo; // PermissionPolicyUser için
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("İnsan Kaynakları")]
+    [DisplayName("Personel (XPO)")]
+    public class Employee : XPObject
+    {
+        public Employee(Session session) : base(session) { }
+
+        private string _employeeNumber;
+        [Size(20)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Personel Numarası")]
+        public string EmployeeNumber { get => _employeeNumber; set => SetPropertyValue(nameof(EmployeeNumber), ref _employeeNumber, value); }
+
+        private string _firstName;
+        [XafDisplayName("Adı")]
+        public string FirstName { get => _firstName; set => SetPropertyValue(nameof(FirstName), ref _firstName, value); }
+
+        private string _lastName;
+        [XafDisplayName("Soyadı")]
+        public string LastName { get => _lastName; set => SetPropertyValue(nameof(LastName), ref _lastName, value); }
+
+        [PersistentAlias("Concat(FirstName, ' ', LastName)")]
+        [XafDisplayName("Tam Adı")]
+        public string FullName => (string)EvaluateAlias(nameof(FullName));
+
+        private string _nationalId;
+        [Size(11)]
+        [XafDisplayName("TC Kimlik Numarası")]
+        public string NationalId { get => _nationalId; set => SetPropertyValue(nameof(NationalId), ref _nationalId, value); }
+
+        private DateTime? _dateOfBirth;
+        [XafDisplayName("Doğum Tarihi")]
+        public DateTime? DateOfBirth { get => _dateOfBirth; set => SetPropertyValue(nameof(DateOfBirth), ref _dateOfBirth, value); }
+
+        private Gender _gender;
+        [XafDisplayName("Cinsiyet")]
+        public Gender Gender { get => _gender; set => SetPropertyValue(nameof(Gender), ref _gender, value); }
+
+        private string _departmentName;
+        [XafDisplayName("Departman")]
+        public string DepartmentName { get => _departmentName; set => SetPropertyValue(nameof(DepartmentName), ref _departmentName, value); }
+
+        private string _positionTitle;
+        [XafDisplayName("Pozisyon/Unvan")]
+        public string PositionTitle { get => _positionTitle; set => SetPropertyValue(nameof(PositionTitle), ref _positionTitle, value); }
+
+        private DateTime? _hireDate;
+        [XafDisplayName("İşe Başlama Tarihi")]
+        public DateTime? HireDate { get => _hireDate; set => SetPropertyValue(nameof(HireDate), ref _hireDate, value); }
+
+        private DateTime? _terminationDate;
+        [XafDisplayName("İşten Ayrılma Tarihi")]
+        public DateTime? TerminationDate { get => _terminationDate; set => SetPropertyValue(nameof(TerminationDate), ref _terminationDate, value); }
+
+        private EmployeeStatus _status;
+        [XafDisplayName("Durumu")]
+        public EmployeeStatus Status { get => _status; set => SetPropertyValue(nameof(Status), ref _status, value); }
+
+        private string _phoneNumber;
+        [Size(20)]
+        [XafDisplayName("Telefon")]
+        public string PhoneNumber { get => _phoneNumber; set => SetPropertyValue(nameof(PhoneNumber), ref _phoneNumber, value); }
+
+        private string _email;
+        [Size(100)]
+        [XafDisplayName("E-posta")]
+        public string Email { get => _email; set => SetPropertyValue(nameof(Email), ref _email, value); }
+
+        private string _address;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Adres")]
+        public string Address { get => _address; set => SetPropertyValue(nameof(Address), ref _address, value); }
+
+        private PermissionPolicyUser _systemUser;
+        [XafDisplayName("Sistem Kullanıcısı")]
+        public PermissionPolicyUser SystemUser
+        {
+            get => _systemUser;
+            set => SetPropertyValue(nameof(SystemUser), ref _systemUser, value);
+        }
+
+        [Association("Employee-LeaveRequests")]
+        [XafDisplayName("İzin Talepleri")]
+        public XPCollection<LeaveRequest> LeaveRequests => GetCollection<LeaveRequest>(nameof(LeaveRequests));
+
+        [Association("Employee-TimesheetEntries")]
+        [XafDisplayName("Puantaj Kayıtları")]
+        public XPCollection<TimesheetEntry> TimesheetEntries => GetCollection<TimesheetEntry>(nameof(TimesheetEntries));
+
+        [Association("Employee-FixedAssetsResponsible")] // Sorumlu olduğu demirbaşlar
+        [XafDisplayName("Sorumlu Olduğu Demirbaşlar")]
+        public XPCollection<FixedAsset> ResponsibleFixedAssets => GetCollection<FixedAsset>(nameof(ResponsibleFixedAssets));
+
+        [Association("Employee-QualityChecksBy")] // Yaptığı kalite kontrolleri
+        [XafDisplayName("Yaptığı Kalite Kontrolleri")]
+        public XPCollection<QualityCheck> QualityChecksPerformed => GetCollection<QualityCheck>(nameof(QualityChecksPerformed));
+
+        [Association("Employee-NonConformancesResponsible")] // Sorumlu olduğu uygunsuzluklar
+        [XafDisplayName("Sorumlu Olduğu Uygunsuzluklar")]
+        public XPCollection<NonConformance> ResponsibleNonConformances => GetCollection<NonConformance>(nameof(ResponsibleNonConformances));
+
+        // Meeting (Event) nesnesindeki Resources (katılımcılar) ile ilişki kurulacaksa,
+        // Event nesnesinde Employee tipinde bir Resource tanımı yapılabilir veya Meeting nesnesinde direkt Employee koleksiyonu tutulabilir.
+        // Şimdilik Meeting nesnesinde Employee koleksiyonu tutacağımızı varsayalım.
+        [Association("Meeting-Attendees")]
+        [XafDisplayName("Katıldığı Toplantılar")]
+        public XPCollection<Meeting> MeetingsAttended => GetCollection<Meeting>(nameof(MeetingsAttended));
+
+        [Association("Employee-StockCountsBy")] // Yaptığı stok sayımları
+        [XafDisplayName("Yaptığı Stok Sayımları")]
+        public XPCollection<StockCount> StockCountsPerformed => GetCollection<StockCount>(nameof(StockCountsPerformed));
+
+        [Association("MaintenanceLog-Technician")] // Yaptığı bakımlar
+        [XafDisplayName("Yaptığı Bakımlar")]
+        public XPCollection<MaintenanceLog> MaintenanceLogsPerformed => GetCollection<MaintenanceLog>(nameof(MaintenanceLogsPerformed));
+
+
+        public override void AfterConstruction() { base.AfterConstruction(); Status = EmployeeStatus.Active; }
+    }
+
+    public enum Gender
+    {
+        [Display(Name = "Belirtilmemiş")] Unspecified = 0,
+        [Display(Name = "Erkek")] Male = 1,
+        [Display(Name = "Kadın")] Female = 2
+    }
+    public enum EmployeeStatus
+    {
+        [Display(Name = "Aktif")] Active = 0,
+        [Display(Name = "İzinli")] OnLeave = 1,
+        [Display(Name = "Ayrıldı")] Terminated = 2
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Equipment.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Equipment.cs
@@ -1,0 +1,93 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Teknik Servis")]
+    [DisplayName("Makine/Ekipman (XPO)")]
+    public class Equipment : XPObject
+    {
+        public Equipment(Session session) : base(session) { }
+
+        private string _equipmentCode;
+        [Size(50)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Ekipman Kodu")]
+        public string EquipmentCode { get => _equipmentCode; set => SetPropertyValue(nameof(EquipmentCode), ref _equipmentCode, value); }
+
+        private string _equipmentName;
+        [Size(255)]
+        [XafDisplayName("Ekipman Adı")]
+        public string EquipmentName { get => _equipmentName; set => SetPropertyValue(nameof(EquipmentName), ref _equipmentName, value); }
+
+        private string _serialNumber;
+        [Indexed(Unique = true)]
+        [XafDisplayName("Seri Numarası")]
+        public string SerialNumber { get => _serialNumber; set => SetPropertyValue(nameof(SerialNumber), ref _serialNumber, value); }
+
+        private string _model;
+        [XafDisplayName("Model")]
+        public string Model { get => _model; set => SetPropertyValue(nameof(Model), ref _model, value); }
+
+        private string _manufacturer;
+        [XafDisplayName("Marka")]
+        public string Manufacturer { get => _manufacturer; set => SetPropertyValue(nameof(Manufacturer), ref _manufacturer, value); }
+
+        private string _category;
+        [XafDisplayName("Kategori")]
+        public string Category { get => _category; set => SetPropertyValue(nameof(Category), ref _category, value); }
+
+        private Customer _customer;
+        [Association("Customer-Equipments")]
+        [XafDisplayName("Müşteri")]
+        public Customer Customer { get => _customer; set => SetPropertyValue(nameof(Customer), ref _customer, value); }
+
+        private DateTime? _installationDate;
+        [XafDisplayName("Kurulum Tarihi")]
+        public DateTime? InstallationDate { get => _installationDate; set => SetPropertyValue(nameof(InstallationDate), ref _installationDate, value); }
+
+        private DateTime? _warrantyEndDate;
+        [XafDisplayName("Garanti Bitiş Tarihi")]
+        public DateTime? WarrantyEndDate { get => _warrantyEndDate; set => SetPropertyValue(nameof(WarrantyEndDate), ref _warrantyEndDate, value); }
+
+        private string _location;
+        [XafDisplayName("Lokasyon")]
+        public string Location { get => _location; set => SetPropertyValue(nameof(Location), ref _location, value); }
+
+        private EquipmentStatus _status;
+        [XafDisplayName("Durum")]
+        public EquipmentStatus Status { get => _status; set => SetPropertyValue(nameof(Status), ref _status, value); }
+
+        private string _notes;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Notlar")]
+        public string Notes { get => _notes; set => SetPropertyValue(nameof(Notes), ref _notes, value); }
+
+        [Association("Equipment-ServiceTickets")]
+        [XafDisplayName("Servis Talepleri")]
+        public XPCollection<ServiceTicket> ServiceTickets => GetCollection<ServiceTicket>(nameof(ServiceTickets));
+
+        [Association("Equipment-MaintenancePlans")]
+        [XafDisplayName("Bakım Planları")]
+        public XPCollection<MaintenancePlan> MaintenancePlans => GetCollection<MaintenancePlan>(nameof(MaintenancePlans));
+
+        [Association("Equipment-MaintenanceLogs")]
+        [XafDisplayName("Bakım Kayıtları")]
+        public XPCollection<MaintenanceLog> MaintenanceLogs => GetCollection<MaintenanceLog>(nameof(MaintenanceLogs));
+
+        public override void AfterConstruction() { base.AfterConstruction(); Status = EquipmentStatus.Active; }
+    }
+
+    public enum EquipmentStatus
+    {
+        [Display(Name = "Aktif")] Active = 0,
+        [Display(Name = "Pasif")] Inactive = 1,
+        [Display(Name = "Bakımda")] UnderMaintenance = 2,
+        [Display(Name = "Arızalı")] OutOfOrder = 3,
+        [Display(Name = "Hurda")] Scrapped = 4
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/FixedAsset.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/FixedAsset.cs
@@ -1,0 +1,103 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Demirbaş Yönetimi")]
+    [DisplayName("Demirbaş (XPO)")]
+    public class FixedAsset : XPObject
+    {
+        public FixedAsset(Session session) : base(session) { }
+
+        private string _assetCode;
+        [Size(50)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Demirbaş Kodu")]
+        public string AssetCode { get => _assetCode; set => SetPropertyValue(nameof(AssetCode), ref _assetCode, value); }
+
+        private string _assetName;
+        [XafDisplayName("Demirbaş Adı")]
+        public string AssetName { get => _assetName; set => SetPropertyValue(nameof(AssetName), ref _assetName, value); }
+
+        private string _description;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Açıklama")]
+        public string Description { get => _description; set => SetPropertyValue(nameof(Description), ref _description, value); }
+
+        private string _category;
+        [XafDisplayName("Kategori")]
+        public string Category { get => _category; set => SetPropertyValue(nameof(Category), ref _category, value); }
+
+        private DateTime _acquisitionDate;
+        [XafDisplayName("Alım Tarihi")]
+        public DateTime AcquisitionDate { get => _acquisitionDate; set => SetPropertyValue(nameof(AcquisitionDate), ref _acquisitionDate, value); }
+
+        private decimal _acquisitionCost;
+        [XafDisplayName("Alım Maliyeti")]
+        public decimal AcquisitionCost { get => _acquisitionCost; set => SetPropertyValue(nameof(AcquisitionCost), ref _acquisitionCost, value); }
+
+        private int _usefulLifeYears;
+        [XafDisplayName("Kullanım Ömrü (Yıl)")]
+        public int UsefulLifeYears { get => _usefulLifeYears; set => SetPropertyValue(nameof(UsefulLifeYears), ref _usefulLifeYears, value); }
+
+        private DepreciationMethodType _depreciationMethod;
+        [XafDisplayName("Amortisman Metodu")]
+        public DepreciationMethodType DepreciationMethod { get => _depreciationMethod; set => SetPropertyValue(nameof(DepreciationMethod), ref _depreciationMethod, value); }
+
+        // Yıllık Amortisman Tutarı (Normal Amortisman için basit hesaplama)
+        [PersistentAlias("IIF(UsefulLifeYears > 0, AcquisitionCost / UsefulLifeYears, 0)")]
+        [XafDisplayName("Yıllık Amortisman Tutarı")]
+        public decimal AnnualDepreciationAmount => Convert.ToDecimal(EvaluateAlias(nameof(AnnualDepreciationAmount)));
+
+        private decimal _accumulatedDepreciation;
+        [XafDisplayName("Birikmiş Amortisman")]
+        // Bu alan genellikle periyodik bir işlemle (örn: yıl sonu) güncellenir.
+        // Basitlik adına manuel girilebilir veya bir Action ile hesaplatılabilir.
+        public decimal AccumulatedDepreciation { get => _accumulatedDepreciation; set => SetPropertyValue(nameof(AccumulatedDepreciation), ref _accumulatedDepreciation, value); }
+
+        [PersistentAlias("AcquisitionCost - AccumulatedDepreciation")]
+        [XafDisplayName("Net Defter Değeri")]
+        public decimal NetBookValue => Convert.ToDecimal(EvaluateAlias(nameof(NetBookValue)));
+
+        private string _location;
+        [XafDisplayName("Lokasyon")]
+        public string Location { get => _location; set => SetPropertyValue(nameof(Location), ref _location, value); }
+
+        private Employee _responsibleEmployee;
+        [Association("Employee-FixedAssetsResponsible")]
+        [XafDisplayName("Sorumlu Personel")]
+        public Employee ResponsibleEmployee { get => _responsibleEmployee; set => SetPropertyValue(nameof(ResponsibleEmployee), ref _responsibleEmployee, value); }
+
+        private FixedAssetStatus _status;
+        [XafDisplayName("Durum")]
+        public FixedAssetStatus Status { get => _status; set => SetPropertyValue(nameof(Status), ref _status, value); }
+
+        public override void AfterConstruction() {
+            base.AfterConstruction();
+            AcquisitionDate = DateTime.Now;
+            DepreciationMethod = DepreciationMethodType.StraightLine;
+            Status = FixedAssetStatus.InUse;
+            UsefulLifeYears = 5; // Varsayılan
+        }
+    }
+
+    public enum DepreciationMethodType
+    {
+        [Display(Name = "Normal Amortisman (Doğrusal)")] StraightLine = 0,
+        [Display(Name = "Azalan Bakiyeler")] DecliningBalance = 1,
+        // Diğer metodlar eklenebilir
+    }
+
+    public enum FixedAssetStatus
+    {
+        [Display(Name = "Kullanımda")] InUse = 0,
+        [Display(Name = "Depoda")] InStorage = 1,
+        [Display(Name = "Bakımda")] UnderMaintenance = 2,
+        [Display(Name = "Hurda")] Scrapped = 3,
+        [Display(Name = "Satıldı")] Sold = 4
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Invoice.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Invoice.cs
@@ -1,0 +1,111 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Finans Yönetimi")]
+    [DisplayName("Fatura (XPO)")]
+    public class Invoice : XPObject
+    {
+        public Invoice(Session session) : base(session) { }
+
+        private string _invoiceNumber;
+        [Size(20)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Fatura Numarası")]
+        public string InvoiceNumber { get => _invoiceNumber; set => SetPropertyValue(nameof(InvoiceNumber), ref _invoiceNumber, value); }
+
+        private DateTime _invoiceDate;
+        [XafDisplayName("Fatura Tarihi")]
+        public DateTime InvoiceDate { get => _invoiceDate; set => SetPropertyValue(nameof(InvoiceDate), ref _invoiceDate, value); }
+
+        private Customer _customer; // Satış faturası ise
+        [Association("Customer-Invoices")]
+        [XafDisplayName("Müşteri")]
+        public Customer Customer { get => _customer; set => SetPropertyValue(nameof(Customer), ref _customer, value); }
+
+        private Supplier _supplier; // Alış faturası ise
+        [Association("Supplier-Invoices")]
+        [XafDisplayName("Tedarikçi")]
+        public Supplier Supplier { get => _supplier; set => SetPropertyValue(nameof(Supplier), ref _supplier, value); }
+
+        private DateTime _dueDate;
+        [XafDisplayName("Vade Tarihi")]
+        public DateTime DueDate { get => _dueDate; set => SetPropertyValue(nameof(DueDate), ref _dueDate, value); }
+
+        // InvoiceItems koleksiyonu üzerinden PersistentAlias ile hesaplamalar
+        [PersistentAlias("InvoiceItems.Sum(LineAmountCalculated)")] // LineAmountCalculated InvoiceItem'da tanımlı
+        [XafDisplayName("Ara Toplam (İndirimli, KDV'siz)")]
+        public decimal SubTotalAfterDiscount => Convert.ToDecimal(EvaluateAlias(nameof(SubTotalAfterDiscount)));
+
+        [PersistentAlias("InvoiceItems.Sum(UnitPrice * Quantity * (DiscountRate/100))")] // Her bir kalemdeki indirim tutarı
+        [XafDisplayName("Toplam İndirim Tutarı")]
+        public decimal TotalDiscountAmount => Convert.ToDecimal(EvaluateAlias(nameof(TotalDiscountAmount)));
+
+        [PersistentAlias("InvoiceItems.Sum(LineVatAmountCalculated)")] // LineVatAmountCalculated InvoiceItem'da tanımlı
+        [XafDisplayName("Toplam KDV")]
+        public decimal TotalVat => Convert.ToDecimal(EvaluateAlias(nameof(TotalVat)));
+
+        [PersistentAlias("InvoiceItems.Sum(LineTotalWithVatCalculated)")] // LineTotalWithVatCalculated InvoiceItem'da tanımlı
+        [XafDisplayName("Genel Toplam (KDV Dahil)")]
+        public decimal GrandTotal => Convert.ToDecimal(EvaluateAlias(nameof(GrandTotal)));
+
+        private string _currency;
+        [Size(3)]
+        [XafDisplayName("Para Birimi")]
+        public string Currency { get => _currency; set => SetPropertyValue(nameof(Currency), ref _currency, value); }
+
+        private InvoiceType _type;
+        [XafDisplayName("Fatura Tipi")]
+        public InvoiceType Type { get => _type; set => SetPropertyValue(nameof(Type), ref _type, value); }
+
+        private PaymentStatus _paymentStatus;
+        [XafDisplayName("Ödeme Durumu")]
+        public PaymentStatus PaymentStatus { get => _paymentStatus; set => SetPropertyValue(nameof(PaymentStatus), ref _paymentStatus, value); }
+
+        private string _notes;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Notlar")]
+        public string Notes { get => _notes; set => SetPropertyValue(nameof(Notes), ref _notes, value); }
+
+        [Association("Invoice-InvoiceItems"), Aggregated]
+        [XafDisplayName("Fatura Kalemleri")]
+        public XPCollection<InvoiceItem> InvoiceItems => GetCollection<InvoiceItem>(nameof(InvoiceItems));
+
+        private Shipment _relatedShipment; // Satış Faturası için
+        [Association("Shipment-Invoices")]
+        [XafDisplayName("İlişkili Sevkiyat")]
+        public Shipment RelatedShipment { get => _relatedShipment; set => SetPropertyValue(nameof(RelatedShipment), ref _relatedShipment, value); }
+
+        private PurchaseOrder _relatedPurchaseOrder; // Alış Faturası için
+        [Association("PurchaseOrder-Invoices")]
+        [XafDisplayName("İlişkili Satınalma Siparişi")]
+        public PurchaseOrder RelatedPurchaseOrder { get => _relatedPurchaseOrder; set => SetPropertyValue(nameof(RelatedPurchaseOrder), ref _relatedPurchaseOrder, value); }
+
+        public override void AfterConstruction() {
+            base.AfterConstruction();
+            InvoiceDate = DateTime.Now;
+            DueDate = DateTime.Now.AddDays(30);
+            Currency = "TRY";
+            Type = InvoiceType.Sales;
+            PaymentStatus = PaymentStatus.Unpaid;
+        }
+    }
+
+    public enum InvoiceType {
+        [Display(Name="Satış Faturası")] Sales,
+        [Display(Name="Alış Faturası")] Purchase,
+        [Display(Name="Satış İade Faturası")] SalesReturn,
+        [Display(Name="Alış İade Faturası")] PurchaseReturn
+    }
+    public enum PaymentStatus {
+        [Display(Name="Ödenmedi")] Unpaid,
+        [Display(Name="Kısmen Ödendi")] PartiallyPaid,
+        [Display(Name="Ödendi")] Paid,
+        [Display(Name="Vadesi Geçti")] Overdue
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/InvoiceItem.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/InvoiceItem.cs
@@ -1,0 +1,126 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+using System; // Convert için
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DisplayName("Fatura Kalemi (XPO)")]
+    public class InvoiceItem : XPObject
+    {
+        public InvoiceItem(Session session) : base(session) { }
+
+        private Invoice _invoice;
+        [Association("Invoice-InvoiceItems")]
+        [Browsable(false)]
+        public Invoice Invoice { get => _invoice; set => SetPropertyValue(nameof(Invoice), ref _invoice, value); }
+
+        private Material _material;
+        [Association("Material-InvoiceItems")]
+        [XafDisplayName("Malzeme/Hizmet")]
+        public Material Material {
+            get => _material;
+            set {
+                if(SetPropertyValue(nameof(Material), ref _material, value))
+                {
+                    if(!IsLoading && Material != null)
+                    {
+                        Description = Material.MaterialName;
+                        Unit = Material.BaseUnit;
+                        UnitPrice = Material.UnitPrice; // Malzemenin satış fiyatını çekebilir
+                    }
+                }
+            }
+        }
+
+        private string _description;
+        [Size(255)]
+        [XafDisplayName("Açıklama")]
+        public string Description { get => _description; set => SetPropertyValue(nameof(Description), ref _description, value); }
+
+        private double _quantity;
+        [XafDisplayName("Miktar")]
+        public double Quantity { get => _quantity; set => SetPropertyValue(nameof(Quantity), ref _quantity, value); }
+
+        private string _unit;
+        [Size(50)]
+        [XafDisplayName("Birim")]
+        public string Unit { get => _unit; set => SetPropertyValue(nameof(Unit), ref _unit, value); }
+
+        private decimal _unitPrice;
+        [XafDisplayName("Birim Fiyat")]
+        public decimal UnitPrice { get => _unitPrice; set => SetPropertyValue(nameof(UnitPrice), ref _unitPrice, value); }
+
+        private decimal _discountRate; // 0-100 arası
+        [XafDisplayName("İndirim Oranı (%)")]
+        public decimal DiscountRate { get => _discountRate; set => SetPropertyValue(nameof(DiscountRate), ref _discountRate, value); }
+
+        private decimal _vatRate; // 0-100 arası
+        [XafDisplayName("KDV Oranı (%)")]
+        public decimal VatRate { get => _vatRate; set => SetPropertyValue(nameof(VatRate), ref _vatRate, value); }
+
+        // Bu alan Invoice'daki PersistentAlias'lar tarafından kullanılacak.
+        [NonPersistent] // Veritabanında tutulmayacak, anlık hesaplanacak.
+        [XafDisplayName("Satır Tutarı (KDV'siz, İndirimli)")]
+        public decimal LineAmountCalculated
+        {
+            get
+            {
+                return (decimal)Quantity * UnitPrice * (1 - DiscountRate / 100);
+            }
+        }
+
+        [NonPersistent]
+        [XafDisplayName("Satır KDV Tutarı")]
+        public decimal LineVatAmountCalculated
+        {
+            get
+            {
+                return LineAmountCalculated * (VatRate / 100);
+            }
+        }
+
+        [NonPersistent]
+        [XafDisplayName("Satır Toplamı (KDV Dahil)")]
+        public decimal LineTotalWithVatCalculated
+        {
+            get
+            {
+                return LineAmountCalculated + LineVatAmountCalculated;
+            }
+        }
+
+        public override void AfterConstruction() {
+            base.AfterConstruction();
+            Unit = "Adet";
+            VatRate = 18;
+            Quantity = 1;
+        }
+
+        // Fatura toplamlarının güncellenmesi için InvoiceItem'daki değişikliklerde
+        // Invoice nesnesinin OnChanged'ını tetiklemek gerekebilir (eğer PersistentAlias kullanılmıyorsa).
+        // Biz Invoice'da PersistentAlias kullandığımız için bu genellikle otomatik olur.
+        // Ancak, bir koleksiyon değişikliğinde (Item Ekleme/Silme) Invoice'un haberdar olması için
+        // Invoice.InvoiceItems getter'ında ListChanged olayına abone olunabilir.
+        protected override void OnChanged(string propertyName, object oldValue, object newValue)
+        {
+            base.OnChanged(propertyName, oldValue, newValue);
+            if (!IsLoading && !IsSaving && Invoice != null)
+            {
+                // Eğer Invoice'daki toplamlar PersistentAlias ile değil de manuel hesaplanıyorsa:
+                // Invoice.UpdateTotals();
+                // Ama PersistentAlias kullandığımız için bu satıra gerek yok.
+                // Sadece Invoice nesnesinin kendisinin değiştiğini bildirmek yeterli olabilir (UI güncellemesi için)
+                 if (propertyName == nameof(Quantity) || propertyName == nameof(UnitPrice) ||
+                     propertyName == nameof(DiscountRate) || propertyName == nameof(VatRate))
+                 {
+                    Invoice.OnChanged(nameof(Invoice.SubTotalAfterDiscount));
+                    Invoice.OnChanged(nameof(Invoice.TotalDiscountAmount));
+                    Invoice.OnChanged(nameof(Invoice.TotalVat));
+                    Invoice.OnChanged(nameof(Invoice.GrandTotal));
+                 }
+            }
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Lead.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Lead.cs
@@ -1,0 +1,139 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+// using DevExpress.Persistent.Validation;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Satış Pazarlama")]
+    [DisplayName("Potansiyel Müşteri (XPO)")]
+    public class Lead : XPObject
+    {
+        public Lead(Session session) : base(session) { }
+
+        private string _leadName;
+        [Size(100)]
+        // [RuleRequiredField("RuleRequiredField for Lead.LeadName", DefaultContexts.Save)]
+        [XafDisplayName("Potansiyel Müşteri Adı")]
+        public string LeadName
+        {
+            get => _leadName;
+            set => SetPropertyValue(nameof(LeadName), ref _leadName, value);
+        }
+
+        private string _companyName;
+        [Size(100)]
+        [XafDisplayName("Firma Adı")]
+        public string CompanyName
+        {
+            get => _companyName;
+            set => SetPropertyValue(nameof(CompanyName), ref _companyName, value);
+        }
+
+        private string _contactPerson;
+        [Size(100)]
+        [XafDisplayName("Yetkili Kişi")]
+        public string ContactPerson
+        {
+            get => _contactPerson;
+            set => SetPropertyValue(nameof(ContactPerson), ref _contactPerson, value);
+        }
+
+        private string _phoneNumber;
+        [Size(20)]
+        [XafDisplayName("Telefon")]
+        public string PhoneNumber
+        {
+            get => _phoneNumber;
+            set => SetPropertyValue(nameof(PhoneNumber), ref _phoneNumber, value);
+        }
+
+        private string _email;
+        [Size(100)]
+        [XafDisplayName("E-posta")]
+        public string Email
+        {
+            get => _email;
+            set => SetPropertyValue(nameof(Email), ref _email, value);
+        }
+
+        private string _source;
+        [XafDisplayName("Kaynak")]
+        public string Source
+        {
+            get => _source;
+            set => SetPropertyValue(nameof(Source), ref _source, value);
+        }
+
+        private LeadStatus _status;
+        [XafDisplayName("Durum")]
+        public LeadStatus Status
+        {
+            get => _status;
+            set => SetPropertyValue(nameof(Status), ref _status, value);
+        }
+
+        private string _description;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Açıklama")]
+        public string Description
+        {
+            get => _description;
+            set => SetPropertyValue(nameof(Description), ref _description, value);
+        }
+
+        private DateTime _createdDate;
+        [XafDisplayName("Oluşturulma Tarihi")]
+        public DateTime CreatedDate
+        {
+            get => _createdDate;
+            set => SetPropertyValue(nameof(CreatedDate), ref _createdDate, value);
+        }
+
+        private bool _isConvertedToCustomer;
+        [XafDisplayName("Müşteriye Dönüştürüldü")]
+        public bool IsConvertedToCustomer
+        {
+            get => _isConvertedToCustomer;
+            set => SetPropertyValue(nameof(IsConvertedToCustomer), ref _isConvertedToCustomer, value);
+        }
+
+        private Customer _convertedCustomer;
+        [Association("Customer-Leads")] // Customer'daki XPCollection ile eşleşir
+        [XafDisplayName("Dönüştürülen Müşteri")]
+        public Customer ConvertedCustomer
+        {
+            get => _convertedCustomer;
+            set => SetPropertyValue(nameof(ConvertedCustomer), ref _convertedCustomer, value);
+        }
+
+        [Association("Lead-SalesOpportunities")]
+        [XafDisplayName("Satış Fırsatları")]
+        public XPCollection<SalesOpportunity> SalesOpportunities => GetCollection<SalesOpportunity>(nameof(SalesOpportunities));
+
+        [Association("Lead-Offers")]
+        [XafDisplayName("Teklifler")]
+        public XPCollection<Offer> Offers => GetCollection<Offer>(nameof(Offers));
+
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            CreatedDate = DateTime.Now;
+            Status = LeadStatus.New;
+        }
+    }
+
+    public enum LeadStatus
+    {
+        [Display(Name = "Yeni")] New = 0,
+        [Display(Name = "İletişime Geçildi")] Contacted = 1,
+        [Display(Name = "Değerlendiriliyor")] Qualified = 2,
+        [Display(Name = "Teklif Verildi")] ProposalSent = 3,
+        [Display(Name = "Kazanılamadı")] Lost = 4,
+        [Display(Name = "Müşteriye Dönüştü")] Converted = 5
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/LeaveRequest.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/LeaveRequest.cs
@@ -1,0 +1,76 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("İnsan Kaynakları")]
+    [DisplayName("İzin Talebi (XPO)")]
+    public class LeaveRequest : XPObject
+    {
+        public LeaveRequest(Session session) : base(session) { }
+
+        private Employee _employee;
+        [Association("Employee-LeaveRequests")]
+        [XafDisplayName("Personel")]
+        public Employee Employee { get => _employee; set => SetPropertyValue(nameof(Employee), ref _employee, value); }
+
+        private string _leaveType;
+        [XafDisplayName("İzin Tipi")] // Örn: Yıllık İzin, Hastalık İzni, Mazeret İzni vb.
+        public string LeaveType { get => _leaveType; set => SetPropertyValue(nameof(LeaveType), ref _leaveType, value); }
+
+        private DateTime _startDate;
+        [XafDisplayName("Başlangıç Tarihi")]
+        public DateTime StartDate { get => _startDate; set => SetPropertyValue(nameof(StartDate), ref _startDate, value); }
+
+        private DateTime _endDate;
+        [XafDisplayName("Bitiş Tarihi")]
+        public DateTime EndDate { get => _endDate; set => SetPropertyValue(nameof(EndDate), ref _endDate, value); }
+
+        // TimeSpan.TotalDays kullanmak daha doğru olabilir, ancak PersistentAlias basit bir çıkarma yapar.
+        // Eğer iş günleri vs. hesabı gerekiyorsa NonPersistent bir property ve getter'da hesaplama daha iyi olur.
+        [PersistentAlias("EndDate - StartDate")] // Bu TimeSpan döndürür, XAF bunu nasıl gösterir kontrol edilmeli.
+                                                 // Daha iyisi: AddDays(1) ile gün sayısı.
+        [XafDisplayName("İzin Süresi (Gün)")]
+        public TimeSpan DurationTimeSpan => (TimeSpan)EvaluateAlias(nameof(DurationTimeSpan));
+
+        [NonPersistent]
+        [XafDisplayName("İzin Süresi (Gün Sayısı)")]
+        public int DurationInDays => DurationTimeSpan.Days + 1;
+
+
+        private string _reason;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Açıklama")]
+        public string Reason { get => _reason; set => SetPropertyValue(nameof(Reason), ref _reason, value); }
+
+        private DateTime _requestDate;
+        [XafDisplayName("Talep Tarihi")]
+        public DateTime RequestDate { get => _requestDate; set => SetPropertyValue(nameof(RequestDate), ref _requestDate, value); }
+
+        private ApprovalStatus _status;
+        [XafDisplayName("Onay Durumu")]
+        public ApprovalStatus Status { get => _status; set => SetPropertyValue(nameof(Status), ref _status, value); }
+
+        private Employee _approvedBy;
+        [XafDisplayName("Onaylayan Yetkili")]
+        public Employee ApprovedBy { get => _approvedBy; set => SetPropertyValue(nameof(ApprovedBy), ref _approvedBy, value); }
+
+        private DateTime? _approvalDate;
+        [XafDisplayName("Onay Tarihi")]
+        public DateTime? ApprovalDate { get => _approvalDate; set => SetPropertyValue(nameof(ApprovalDate), ref _approvalDate, value); }
+
+        public override void AfterConstruction() { base.AfterConstruction(); RequestDate = DateTime.Now; Status = ApprovalStatus.Pending; StartDate = DateTime.Today; EndDate = DateTime.Today.AddDays(1); }
+    }
+
+    public enum ApprovalStatus
+    {
+        [Display(Name = "Beklemede")] Pending = 0,
+        [Display(Name = "Onaylandı")] Approved = 1,
+        [Display(Name = "Reddedildi")] Rejected = 2,
+        [Display(Name = "İptal Edildi")] Cancelled = 3
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/MaintenanceLog.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/MaintenanceLog.cs
@@ -1,0 +1,76 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Teknik Servis")]
+    [DisplayName("Bakım Kaydı (XPO)")]
+    public class MaintenanceLog : XPObject
+    {
+        public MaintenanceLog(Session session) : base(session) { }
+
+        private Equipment _equipment;
+        [Association("Equipment-MaintenanceLogs")]
+        [XafDisplayName("Ekipman")]
+        public Equipment Equipment { get => _equipment; set => SetPropertyValue(nameof(Equipment), ref _equipment, value); }
+
+        private MaintenancePlan _maintenancePlan;
+        [Association("MaintenancePlan-MaintenanceLogs")]
+        [XafDisplayName("İlişkili Bakım Planı")]
+        public MaintenancePlan MaintenancePlan { get => _maintenancePlan; set => SetPropertyValue(nameof(MaintenancePlan), ref _maintenancePlan, value); }
+
+        private ServiceTicket _serviceTicket;
+        [Association("ServiceTicket-MaintenanceLogs")]
+        [XafDisplayName("İlişkili Servis Talebi")] // Eğer bir servis talebi üzerinden yapıldıysa
+        public ServiceTicket ServiceTicket { get => _serviceTicket; set => SetPropertyValue(nameof(ServiceTicket), ref _serviceTicket, value); }
+
+        private DateTime _maintenanceDate;
+        [XafDisplayName("Bakım Tarihi")]
+        public DateTime MaintenanceDate { get => _maintenanceDate; set => SetPropertyValue(nameof(MaintenanceDate), ref _maintenanceDate, value); }
+
+        private string _workPerformed;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Yapılan İşlemler")]
+        public string WorkPerformed { get => _workPerformed; set => SetPropertyValue(nameof(WorkPerformed), ref _workPerformed, value); }
+
+        private Employee _technician; // Employee nesnesine referans
+        [XafDisplayName("Teknisyen")]
+        public Employee Technician { get => _technician; set => SetPropertyValue(nameof(Technician), ref _technician, value); }
+
+        private string _materialsUsed;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Kullanılan Malzemeler")] // Daha sonra XPCollection<MaterialUsage> gibi bir yapıya dönüşebilir
+        public string MaterialsUsed { get => _materialsUsed; set => SetPropertyValue(nameof(MaterialsUsed), ref _materialsUsed, value); }
+
+        private decimal _cost;
+        [XafDisplayName("Maliyet")]
+        public decimal Cost { get => _cost; set => SetPropertyValue(nameof(Cost), ref _cost, value); }
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            MaintenanceDate = DateTime.Now;
+            // Eğer MaintenancePlan seçiliyse, Ekipmanı oradan alabiliriz.
+            if (MaintenancePlan != null)
+            {
+                Equipment = MaintenancePlan.Equipment;
+            }
+        }
+
+        protected override void OnSaved()
+        {
+            base.OnSaved();
+            // Bakım yapıldıktan sonra ilgili MaintenancePlan'ın LastMaintenanceDate'ini güncelleyebiliriz.
+            if (MaintenancePlan != null && MaintenancePlan.LastMaintenanceDate < MaintenanceDate)
+            {
+                MaintenancePlan.LastMaintenanceDate = MaintenanceDate;
+                // MaintenancePlan.CalculateNextDueDate(); // Bu zaten OnChanged ile tetikleniyor olacak.
+                // Session.CommitChanges(); // Eğer ayrı bir UnitOfWork içinde değilse. XAF bunu yönetir.
+            }
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/MaintenancePlan.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/MaintenancePlan.cs
@@ -1,0 +1,115 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Teknik Servis")]
+    [DisplayName("Periyodik Bakım Planı (XPO)")]
+    public class MaintenancePlan : XPObject
+    {
+        public MaintenancePlan(Session session) : base(session) { }
+
+        private string _planName;
+        [Size(100)] // EF Core'da 50 idi, XPO için biraz daha uzun olabilir.
+        [XafDisplayName("Plan Adı")]
+        public string PlanName { get => _planName; set => SetPropertyValue(nameof(PlanName), ref _planName, value); }
+
+        private Equipment _equipment;
+        [Association("Equipment-MaintenancePlans")]
+        [XafDisplayName("Ekipman")]
+        public Equipment Equipment { get => _equipment; set => SetPropertyValue(nameof(Equipment), ref _equipment, value); }
+
+        private string _maintenanceType;
+        [XafDisplayName("Bakım Tipi")] // Örn: Yağ Değişimi, Filtre Kontrolü
+        public string MaintenanceType { get => _maintenanceType; set => SetPropertyValue(nameof(MaintenanceType), ref _maintenanceType, value); }
+
+        private MaintenanceFrequency _frequency;
+        [XafDisplayName("Sıklık")]
+        public MaintenanceFrequency Frequency { get => _frequency; set => SetPropertyValue(nameof(Frequency), ref _frequency, value); }
+
+        private int _frequencyValue;
+        [XafDisplayName("Sıklık Değeri")] // Frequency'e göre (örn: Frequency = Ay ise Değer = 3 -> 3 Ayda bir)
+        public int FrequencyValue { get => _frequencyValue; set => SetPropertyValue(nameof(FrequencyValue), ref _frequencyValue, value); }
+
+        private DateTime? _lastMaintenanceDate;
+        [XafDisplayName("Son Bakım Tarihi")]
+        public DateTime? LastMaintenanceDate { get => _lastMaintenanceDate; set => SetPropertyValue(nameof(LastMaintenanceDate), ref _lastMaintenanceDate, value); }
+
+        private DateTime? _nextDueDate;
+        [XafDisplayName("Bir Sonraki Bakım Tarihi")]
+        // Bu alan bir Controller veya OnChanged metodu ile otomatik hesaplanabilir.
+        // Örneğin LastMaintenanceDate veya Frequency değiştiğinde.
+        public DateTime? NextDueDate { get => _nextDueDate; set => SetPropertyValue(nameof(NextDueDate), ref _nextDueDate, value); }
+
+        private string _description;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Açıklama")]
+        public string Description { get => _description; set => SetPropertyValue(nameof(Description), ref _description, value); }
+
+        private bool _isActive;
+        [XafDisplayName("Aktif Plan")]
+        public bool IsActive { get => _isActive; set => SetPropertyValue(nameof(IsActive), ref _isActive, value); }
+
+        [Association("MaintenancePlan-MaintenanceLogs")]
+        [XafDisplayName("Bu Plana Ait Bakım Kayıtları")]
+        public XPCollection<MaintenanceLog> MaintenanceLogs => GetCollection<MaintenanceLog>(nameof(MaintenanceLogs));
+
+        public override void AfterConstruction() { base.AfterConstruction(); FrequencyValue = 1; IsActive = true; }
+
+        // NextDueDate'yi hesaplamak için bir metod (Controller'dan veya OnChanged'den çağrılabilir)
+        public void CalculateNextDueDate()
+        {
+            if (LastMaintenanceDate.HasValue && IsActive)
+            {
+                DateTime newDueDate = LastMaintenanceDate.Value;
+                switch (Frequency)
+                {
+                    case MaintenanceFrequency.Daily:
+                        newDueDate = newDueDate.AddDays(FrequencyValue);
+                        break;
+                    case MaintenanceFrequency.Weekly:
+                        newDueDate = newDueDate.AddDays(7 * FrequencyValue);
+                        break;
+                    case MaintenanceFrequency.Monthly:
+                        newDueDate = newDueDate.AddMonths(FrequencyValue);
+                        break;
+                    case MaintenanceFrequency.Yearly:
+                        newDueDate = newDueDate.AddYears(FrequencyValue);
+                        break;
+                    // ByOperationHours ve ByUsageCount için farklı bir mantık gerekir (sayaç takibi)
+                }
+                NextDueDate = newDueDate;
+            }
+            else
+            {
+                NextDueDate = null;
+            }
+        }
+
+        protected override void OnChanged(string propertyName, object oldValue, object newValue)
+        {
+            base.OnChanged(propertyName, oldValue, newValue);
+            if (!IsLoading && !IsSaving)
+            {
+                if (propertyName == nameof(LastMaintenanceDate) || propertyName == nameof(Frequency) || propertyName == nameof(FrequencyValue) || propertyName == nameof(IsActive))
+                {
+                    CalculateNextDueDate();
+                }
+            }
+        }
+    }
+
+    public enum MaintenanceFrequency
+    {
+        [Display(Name = "Günlük")] Daily = 0,
+        [Display(Name = "Haftalık")] Weekly = 1,
+        [Display(Name = "Aylık")] Monthly = 2,
+        [Display(Name = "Yıllık")] Yearly = 3,
+        [Display(Name = "Çalışma Saatine Göre")] ByOperationHours = 4, // Bu tipler için sayaç takibi gerekir
+        [Display(Name = "Kullanıma Göre")] ByUsageCount = 5 // Bu tipler için sayaç takibi gerekir
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Material.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Material.cs
@@ -1,0 +1,135 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Malzeme Yönetimi")]
+    [DisplayName("Malzeme/Ürün (XPO)")]
+    public class Material : XPObject
+    {
+        public Material(Session session) : base(session) { }
+
+        private string _materialCode;
+        [Size(50)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Malzeme Kodu")]
+        public string MaterialCode
+        {
+            get => _materialCode;
+            set => SetPropertyValue(nameof(MaterialCode), ref _materialCode, value);
+        }
+
+        private string _materialName;
+        [Size(255)]
+        [XafDisplayName("Malzeme Adı")]
+        public string MaterialName
+        {
+            get => _materialName;
+            set => SetPropertyValue(nameof(MaterialName), ref _materialName, value);
+        }
+
+        private string _description;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Açıklama")]
+        public string Description
+        {
+            get => _description;
+            set => SetPropertyValue(nameof(Description), ref _description, value);
+        }
+
+        private string _baseUnit;
+        [Size(50)]
+        [XafDisplayName("Temel Birim")]
+        public string BaseUnit
+        {
+            get => _baseUnit;
+            set => SetPropertyValue(nameof(BaseUnit), ref _baseUnit, value);
+        }
+
+        private decimal _unitCost;
+        [XafDisplayName("Birim Maliyet (Alış)")]
+        public decimal UnitCost
+        {
+            get => _unitCost;
+            set => SetPropertyValue(nameof(UnitCost), ref _unitCost, value);
+        }
+
+        private decimal _unitPrice;
+        [XafDisplayName("Birim Fiyat (Satış)")]
+        public decimal UnitPrice
+        {
+            get => _unitPrice;
+            set => SetPropertyValue(nameof(UnitPrice), ref _unitPrice, value);
+        }
+
+        private string _category;
+        [XafDisplayName("Kategori")]
+        public string Category
+        {
+            get => _category;
+            set => SetPropertyValue(nameof(Category), ref _category, value);
+        }
+
+        private bool _trackStock;
+        [XafDisplayName("Stok Takibi")]
+        public bool TrackStock
+        {
+            get => _trackStock;
+            set => SetPropertyValue(nameof(TrackStock), ref _trackStock, value);
+        }
+
+        [XafDisplayName("Toplam Stok Miktarı")]
+        [PersistentAlias("StockTransactions.Sum(Quantity)")]
+        public double TotalStockQuantity => TrackStock ? Convert.ToDouble(EvaluateAlias(nameof(TotalStockQuantity))) : 0;
+
+        [Association("Material-StockTransactions")]
+        public XPCollection<StockTransaction> StockTransactions => GetCollection<StockTransaction>(nameof(StockTransactions));
+
+        [Association("Material-BillOfMaterialsProduct")] // Bu malzemenin üretildiği ürün ağaçları
+        [XafDisplayName("Ürün Ağaçları (Mamul Olarak)")]
+        public XPCollection<BillOfMaterials> BillOfMaterialsAsProduct => GetCollection<BillOfMaterials>(nameof(BillOfMaterialsAsProduct));
+
+        [Association("Material-BomItems")] // Bu malzemenin kullanıldığı ürün ağacı kalemleri
+        [XafDisplayName("Ürün Ağacı Kalemleri (Hammadde/Yarı Mamul Olarak)")]
+        public XPCollection<BomItem> BomItems => GetCollection<BomItem>(nameof(BomItems));
+
+        [Association("Material-RoutingProduct")]
+        [XafDisplayName("Üretim Rotaları (Mamul Olarak)")]
+        public XPCollection<Routing> RoutingsAsProduct => GetCollection<Routing>(nameof(RoutingsAsProduct));
+
+        [Association("Material-ProductionOrderProduct")]
+        [XafDisplayName("Üretim Emirleri (Mamul Olarak)")]
+        public XPCollection<ProductionOrder> ProductionOrdersAsProduct => GetCollection<ProductionOrder>(nameof(ProductionOrdersAsProduct));
+
+        [Association("Material-ProductionOrderMaterialReq")]
+        [XafDisplayName("Üretim Emri Malzeme İhtiyaçları (Hammadde/Yarı Mamul Olarak)")]
+        public XPCollection<ProductionOrderMaterialRequirement> ProductionOrderMaterialRequirements => GetCollection<ProductionOrderMaterialRequirement>(nameof(ProductionOrderMaterialRequirements));
+
+        [Association("Material-ShipmentItems")]
+        [XafDisplayName("Sevkiyat Kalemleri")]
+        public XPCollection<ShipmentItem> ShipmentItems => GetCollection<ShipmentItem>(nameof(ShipmentItems));
+
+        [Association("Material-InvoiceItems")]
+        [XafDisplayName("Fatura Kalemleri")]
+        public XPCollection<InvoiceItem> InvoiceItems => GetCollection<InvoiceItem>(nameof(InvoiceItems));
+
+        [Association("Material-QualityChecks")]
+        [XafDisplayName("Kalite Kontrol Kayıtları")]
+        public XPCollection<QualityCheck> QualityChecks => GetCollection<QualityCheck>(nameof(QualityChecks));
+
+        [Association("Material-StockCountItems")]
+        [XafDisplayName("Stok Sayım Kalemleri")]
+        public XPCollection<StockCountItem> StockCountItems => GetCollection<StockCountItem>(nameof(StockCountItems));
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            BaseUnit = "Adet";
+            TrackStock = true;
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Meeting.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Meeting.cs
@@ -1,0 +1,85 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Persistent.BaseImpl.Xpo; // Event için
+using DevExpress.Xpo;
+using System.ComponentModel;
+using System.Collections.Generic; // IList için
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Organizasyon")]
+    [DisplayName("Toplantı (XPO)")]
+    // Event sınıfı zaten XPObject'tan (veya XPCustomObject'tan) türemiştir.
+    public class Meeting : Event
+    {
+        public Meeting(Session session) : base(session) { }
+
+        // Event sınıfında Subject, Location, StartOn, EndOn, AllDay, Description, Label, Status, Reminder gibi alanlar zaten var.
+        // Bunları kullanabilir veya XafDisplayName ile etiketlerini değiştirebiliriz.
+        // Veya ek alanlar ekleyebiliriz.
+
+        // Örneğin, Event.Subject yerine daha spesifik bir alan adı kullanmak istersek:
+        private string _meetingTitle;
+        [XafDisplayName("Toplantı Başlığı")] // Event.Subject yerine bu görünebilir (Model Editor'den ayarlanabilir)
+        public string MeetingTitle
+        {
+            get => _meetingTitle;
+            set => SetPropertyValue(nameof(MeetingTitle), ref _meetingTitle, value);
+        }
+
+        private string _agenda;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Gündem")]
+        public string Agenda
+        {
+            get => _agenda;
+            set => SetPropertyValue(nameof(Agenda), ref _agenda, value);
+        }
+
+        private string _minutes; // Toplantı tutanağı
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Toplantı Notları/Tutanağı")]
+        public string Minutes
+        {
+            get => _minutes;
+            set => SetPropertyValue(nameof(Minutes), ref _minutes, value);
+        }
+
+        // Event nesnesinde Resources özelliği zaten var. Bu, katılımcıları (örn: Employee, Contact)
+        // veya toplantı odası gibi kaynakları temsil etmek için kullanılabilir.
+        // Eğer Employee nesnelerini doğrudan katılımcı olarak saklamak istiyorsak:
+        [Association("Meeting-Attendees")]
+        [XafDisplayName("Katılımcı Personeller")]
+        public XPCollection<Employee> AttendeesEmployee => GetCollection<Employee>(nameof(AttendeesEmployee));
+
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            // Varsayılan değerler
+            Label = 0; // Renk etiketi (0-10)
+            Status = 1; // AppointmentStatus (0: Free, 1: Tentative, 2: Busy, 3: OutOfOffice, 4: WorkingElsewhere)
+            // StartOn ve EndOn kullanıcı tarafından girilmeli veya varsayılan atanabilir.
+            StartOn = System.DateTime.Now.AddHours(1);
+            EndOn = System.DateTime.Now.AddHours(2);
+        }
+
+        // Event.Subject'ı MeetingTitle ile senkronize tutmak istersek (opsiyonel):
+        protected override void OnChanged(string propertyName, object oldValue, object newValue)
+        {
+            base.OnChanged(propertyName, oldValue, newValue);
+            if (!IsLoading)
+            {
+                if (propertyName == nameof(MeetingTitle))
+                {
+                    Subject = MeetingTitle; // Event'in Subject'ini güncelle
+                }
+                else if (propertyName == nameof(Subject) && MeetingTitle != Subject)
+                {
+                    MeetingTitle = Subject; // Eğer Subject dışarıdan değişirse MeetingTitle'ı güncelle
+                }
+            }
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/NonConformance.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/NonConformance.cs
@@ -1,0 +1,79 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Kalite Yönetimi")]
+    [DisplayName("Uygunsuzluk Kaydı (XPO)")]
+    public class NonConformance : XPObject
+    {
+        public NonConformance(Session session) : base(session) { }
+
+        private string _ncNumber;
+        [Size(20)]
+        [Indexed(Unique = true)] // Otomatik numara için Controller eklenecek
+        [XafDisplayName("Uygunsuzluk No")]
+        public string NcNumber { get => _ncNumber; set => SetPropertyValue(nameof(NcNumber), ref _ncNumber, value); }
+
+        private DateTime _detectionDate;
+        [XafDisplayName("Tespit Tarihi")]
+        public DateTime DetectionDate { get => _detectionDate; set => SetPropertyValue(nameof(DetectionDate), ref _detectionDate, value); }
+
+        private QualityCheck _relatedQualityCheck;
+        [Association("QualityCheck-NonConformances")]
+        [XafDisplayName("İlgili Kalite Kontrol Kaydı")]
+        public QualityCheck RelatedQualityCheck { get => _relatedQualityCheck; set => SetPropertyValue(nameof(RelatedQualityCheck), ref _relatedQualityCheck, value); }
+
+        private string _description;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Uygunsuzluk Açıklaması")]
+        public string Description { get => _description; set => SetPropertyValue(nameof(Description), ref _description, value); }
+
+        private string _rootCauseAnalysis;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Kök Neden Analizi")]
+        public string RootCauseAnalysis { get => _rootCauseAnalysis; set => SetPropertyValue(nameof(RootCauseAnalysis), ref _rootCauseAnalysis, value); }
+
+        private string _correctiveAction;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Düzeltici Faaliyet")]
+        public string CorrectiveAction { get => _correctiveAction; set => SetPropertyValue(nameof(CorrectiveAction), ref _correctiveAction, value); }
+
+        private string _preventiveAction;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Önleyici Faaliyet")]
+        public string PreventiveAction { get => _preventiveAction; set => SetPropertyValue(nameof(PreventiveAction), ref _preventiveAction, value); }
+
+        private Employee _responsiblePerson;
+        [Association("Employee-NonConformancesResponsible")]
+        [XafDisplayName("Sorumlu Kişi")]
+        public Employee ResponsiblePerson { get => _responsiblePerson; set => SetPropertyValue(nameof(ResponsiblePerson), ref _responsiblePerson, value); }
+
+        private DateTime? _dueDate;
+        [XafDisplayName("Termin Tarihi")]
+        public DateTime? DueDate { get => _dueDate; set => SetPropertyValue(nameof(DueDate), ref _dueDate, value); }
+
+        private NonConformanceStatus _status;
+        [XafDisplayName("Durum")]
+        public NonConformanceStatus Status { get => _status; set => SetPropertyValue(nameof(Status), ref _status, value); }
+
+        public override void AfterConstruction() {
+            base.AfterConstruction();
+            DetectionDate = DateTime.Now;
+            Status = NonConformanceStatus.Open;
+        }
+    }
+
+    public enum NonConformanceStatus
+    {
+        [Display(Name = "Açık")] Open = 0,
+        [Display(Name = "İnceleniyor")] InProgress = 1,
+        [Display(Name = "Çözüldü")] Resolved = 2,
+        [Display(Name = "Doğrulandı ve Kapatıldı")] ClosedVerified = 3,
+        [Display(Name = "İptal Edildi")] Cancelled = 4
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Offer.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Offer.cs
@@ -1,0 +1,187 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+using DevExpress.Persistent.BaseImpl.Xpo; // PermissionPolicyUser için
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Satış Pazarlama")]
+    [DisplayName("Teklif (XPO)")]
+    public class Offer : XPObject
+    {
+        public Offer(Session session) : base(session) { }
+
+        private string _offerNumber;
+        [Size(20)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Teklif Numarası")]
+        public string OfferNumber
+        {
+            get => _offerNumber;
+            set => SetPropertyValue(nameof(OfferNumber), ref _offerNumber, value);
+        }
+
+        private DateTime _offerDate;
+        [XafDisplayName("Teklif Tarihi")]
+        public DateTime OfferDate
+        {
+            get => _offerDate;
+            set => SetPropertyValue(nameof(OfferDate), ref _offerDate, value);
+        }
+
+        private Customer _customer;
+        [Association("Customer-Offers")]
+        [XafDisplayName("Müşteri")]
+        public Customer Customer
+        {
+            get => _customer;
+            set => SetPropertyValue(nameof(Customer), ref _customer, value);
+        }
+
+        private Lead _lead;
+        [Association("Lead-Offers")]
+        [XafDisplayName("Potansiyel Müşteri")]
+        public Lead Lead
+        {
+            get => _lead;
+            set => SetPropertyValue(nameof(Lead), ref _lead, value);
+        }
+
+        private SalesOpportunity _salesOpportunity;
+        [Association("SalesOpportunity-Offers")]
+        [XafDisplayName("Satış Fırsatı")]
+        public SalesOpportunity SalesOpportunity
+        {
+            get => _salesOpportunity;
+            set => SetPropertyValue(nameof(SalesOpportunity), ref _salesOpportunity, value);
+        }
+
+        private DateTime _validUntilDate;
+        [XafDisplayName("Geçerlilik Tarihi")]
+        public DateTime ValidUntilDate
+        {
+            get => _validUntilDate;
+            set => SetPropertyValue(nameof(ValidUntilDate), ref _validUntilDate, value);
+        }
+
+        private decimal _totalAmount;
+        [XafDisplayName("Toplam Tutar")]
+        public decimal TotalAmount // Bu alan Controller veya OnChanged ile güncellenecek
+        {
+            get => _totalAmount;
+            set => SetPropertyValue(nameof(TotalAmount), ref _totalAmount, value);
+        }
+
+        private string _currency;
+        [Size(3)]
+        [XafDisplayName("Para Birimi")]
+        public string Currency
+        {
+            get => _currency;
+            set => SetPropertyValue(nameof(Currency), ref _currency, value);
+        }
+
+        private OfferStatus _status;
+        [XafDisplayName("Teklif Durumu")]
+        public OfferStatus Status
+        {
+            get => _status;
+            set => SetPropertyValue(nameof(Status), ref _status, value);
+        }
+
+        private PermissionPolicyUser _preparedBy; // XPO User
+        [XafDisplayName("Hazırlayan")]
+        public PermissionPolicyUser PreparedBy
+        {
+            get => _preparedBy;
+            set => SetPropertyValue(nameof(PreparedBy), ref _preparedBy, value);
+        }
+
+        private string _notes;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Açıklamalar / Notlar")]
+        public string Notes
+        {
+            get => _notes;
+            set => SetPropertyValue(nameof(Notes), ref _notes, value);
+        }
+
+        [Association("Offer-OfferItems"), Aggregated]
+        [XafDisplayName("Teklif Kalemleri")]
+        public XPCollection<OfferItem> OfferItems
+        {
+            get {
+                XPCollection<OfferItem> items = GetCollection<OfferItem>(nameof(OfferItems));
+                items.ListChanged += OfferItems_ListChanged; // Toplamı güncellemek için
+                return items;
+            }
+        }
+
+        private void OfferItems_ListChanged(object sender, ListChangedEventArgs e)
+        {
+            // Bir kalem eklendiğinde, silindiğinde veya bir kalemin kendisi değiştiğinde (örn: miktarı)
+            // bu olay tetiklenir. Ancak bir kalemin içindeki property değiştiğinde bu olay doğrudan tetiklenmez.
+            // OfferItem içindeki property'lerin set metodlarında Offer.UpdateTotalAmount çağrılmalı.
+            if (e.ListChangedType == ListChangedType.ItemAdded ||
+                e.ListChangedType == ListChangedType.ItemDeleted ||
+                e.ListChangedType == ListChangedType.Reset) // Reset tüm koleksiyon değiştiğinde
+            {
+                UpdateTotalAmount();
+            }
+        }
+
+        public void UpdateTotalAmount()
+        {
+            if (IsLoading || IsSaving) return;
+
+            decimal currentTotal = 0;
+            foreach (OfferItem item in OfferItems)
+            {
+                currentTotal += item.LineTotalWithVat;
+            }
+            TotalAmount = currentTotal;
+            // OnChanged(nameof(TotalAmount)); // Eğer TotalAmount bir PersistentAlias değilse ve UI'ın hemen güncellenmesi isteniyorsa.
+                                            // Bizim senaryomuzda TotalAmount normal bir property, bu yüzden SetPropertyValue bunu halleder.
+        }
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            OfferDate = DateTime.Now;
+            ValidUntilDate = DateTime.Now.AddDays(30);
+            Currency = "TRY";
+            Status = OfferStatus.Draft;
+            // Hazırlayan kullanıcıyı otomatik atama (SecuritySystem XPO ile uyumlu olmalı)
+            // if(SecuritySystem.CurrentUser != null && Session.IsObjectFitForCriteria<PermissionPolicyUser>(SecuritySystem.CurrentUser, CriteriaOperator.Parse("Oid = ?", SecuritySystem.CurrentUserId)))
+            //    PreparedBy = Session.GetObjectByKey<PermissionPolicyUser>(SecuritySystem.CurrentUserId);
+        }
+
+        protected override void OnLoaded()
+        {
+            base.OnLoaded();
+            // OfferItems koleksiyonu yüklendiğinde ListChanged olayına abone olalım
+            // Bu, nesne yüklendikten sonra koleksiyon değişikliklerini de yakalamak için.
+            // Ancak GetCollection içinde abone olmak daha yaygın.
+            // OfferItems.ListChanged += OfferItems_ListChanged;
+        }
+
+        protected override void OnSaving()
+        {
+            UpdateTotalAmount(); // Kaydetmeden önce son bir kez toplamı güncelle
+            base.OnSaving();
+        }
+    }
+
+    public enum OfferStatus
+    {
+        [Display(Name = "Taslak")] Draft = 0,
+        [Display(Name = "Gönderildi")] Sent = 1,
+        [Display(Name = "Kabul Edildi")] Accepted = 2,
+        [Display(Name = "Reddedildi")] Rejected = 3,
+        [Display(Name = "Revize Edildi")] Revised = 4,
+        [Display(Name = "İptal Edildi")] Cancelled = 5
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/OfferItem.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/OfferItem.cs
@@ -1,0 +1,151 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DisplayName("Teklif Kalemi (XPO)")]
+    public class OfferItem : XPObject
+    {
+        public OfferItem(Session session) : base(session) { }
+
+        private Offer _offer;
+        [Association("Offer-OfferItems")]
+        [Browsable(false)]
+        public Offer Offer
+        {
+            get => _offer;
+            // OfferItems koleksiyonu Aggregated olduğu için Offer set edildiğinde
+            // bu item Offer'ın OfferItems koleksiyonuna otomatik eklenir/çıkarılır.
+            set => SetPropertyValue(nameof(Offer), ref _offer, value);
+        }
+
+        private string _productName;
+        [Size(255)]
+        [XafDisplayName("Ürün/Hizmet Adı")]
+        public string ProductName
+        {
+            get => _productName;
+            set => SetPropertyValue(nameof(ProductName), ref _productName, value);
+        }
+
+        private string _description;
+        [XafDisplayName("Açıklama")]
+        public string Description
+        {
+            get => _description;
+            set => SetPropertyValue(nameof(Description), ref _description, value);
+        }
+
+        private double _quantity;
+        [XafDisplayName("Miktar")]
+        public double Quantity
+        {
+            get => _quantity;
+            set {
+                if(SetPropertyValue(nameof(Quantity), ref _quantity, value)) {
+                    // PersistentAlias kullanmadığımız için ana nesneyi bilgilendirmeliyiz
+                    if (!IsLoading && Offer != null) Offer.UpdateTotalAmount();
+                }
+            }
+        }
+
+        private string _unit;
+        [Size(50)]
+        [XafDisplayName("Birim")]
+        public string Unit
+        {
+            get => _unit;
+            set => SetPropertyValue(nameof(Unit), ref _unit, value);
+        }
+
+        private decimal _unitPrice;
+        [XafDisplayName("Birim Fiyat")]
+        public decimal UnitPrice
+        {
+            get => _unitPrice;
+            set {
+                if(SetPropertyValue(nameof(UnitPrice), ref _unitPrice, value)) {
+                    if (!IsLoading && Offer != null) Offer.UpdateTotalAmount();
+                }
+            }
+        }
+
+        private decimal _discountRate;
+        [XafDisplayName("İndirim Oranı (%)")]
+        public decimal DiscountRate
+        {
+            get => _discountRate;
+            set {
+                if(SetPropertyValue(nameof(DiscountRate), ref _discountRate, value)) {
+                    if (!IsLoading && Offer != null) Offer.UpdateTotalAmount();
+                }
+            }
+        }
+
+        private decimal _vatRate;
+        [XafDisplayName("KDV Oranı (%)")]
+        public decimal VatRate
+        {
+            get => _vatRate;
+            set {
+                if(SetPropertyValue(nameof(VatRate), ref _vatRate, value)) {
+                    if (!IsLoading && Offer != null) Offer.UpdateTotalAmount();
+                }
+            }
+        }
+
+        // PersistentAlias yerine manuel hesaplama yapalım, Offer.UpdateTotalAmount tarafından kullanılacak.
+        [NonPersistent] // Bu alan veritabanında saklanmayacak
+        [XafDisplayName("Satır Tutarı (KDV'siz, İndirimli)")]
+        public decimal LineAmountCalculated
+        {
+            get
+            {
+                return (decimal)Quantity * UnitPrice * (1 - DiscountRate / 100);
+            }
+        }
+
+        [NonPersistent]
+        [XafDisplayName("Satır KDV Tutarı")]
+        public decimal LineVatAmountCalculated
+        {
+            get
+            {
+                return LineAmountCalculated * (VatRate / 100);
+            }
+        }
+
+        [NonPersistent]
+        [XafDisplayName("Satır Toplamı (KDV Dahil)")]
+        public decimal LineTotalWithVat
+        {
+            get
+            {
+                return LineAmountCalculated + LineVatAmountCalculated;
+            }
+        }
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            Unit = "Adet";
+            VatRate = 18;
+            Quantity = 1;
+        }
+
+        // Bir OfferItem silindiğinde Offer'ın toplamını güncellemek için.
+        protected override void OnDeleting()
+        {
+            if (Offer != null)
+            {
+                // Bu item silinmeden hemen önce Offer'a haber verelim ki
+                // Offer, bu item hariç diğerleriyle toplamını güncelleyebilsin.
+                // Ya da Offer.OfferItems.ListChanged olayı bunu zaten yakalar.
+                // En temizi Offer.OfferItems.ListChanged olayının ItemDeleted durumunu işlemesi.
+            }
+            base.OnDeleting();
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ProductionOrder.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ProductionOrder.cs
@@ -1,0 +1,116 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Üretim Yönetimi")]
+    [DisplayName("Üretim Emri (XPO)")]
+    public class ProductionOrder : XPObject
+    {
+        public ProductionOrder(Session session) : base(session) { }
+
+        private string _orderNumber;
+        [Size(20)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Üretim Emri No")]
+        public string OrderNumber { get => _orderNumber; set => SetPropertyValue(nameof(OrderNumber), ref _orderNumber, value); }
+
+        private Material _product;
+        [Association("Material-ProductionOrderProduct")]
+        [XafDisplayName("Üretilecek Ürün")]
+        public Material Product {
+            get => _product;
+            set {
+                if(SetPropertyValue(nameof(Product), ref _product, value))
+                {
+                    if(!IsLoading && Product != null)
+                    {
+                        Unit = Product.BaseUnit;
+                        // İlgili BOM ve Rota'yı otomatik çekebiliriz
+                        // BillOfMaterials = Session.FindObject<BillOfMaterials>(CriteriaOperator.Parse("Product.Oid = ? And IsActive = true", Product.Oid));
+                        // Routing = Session.FindObject<Routing>(CriteriaOperator.Parse("Product.Oid = ? And IsActive = true", Product.Oid));
+                    }
+                }
+            }
+        }
+
+        private double _quantityToProduce;
+        [XafDisplayName("Üretilecek Miktar")]
+        public double QuantityToProduce { get => _quantityToProduce; set => SetPropertyValue(nameof(QuantityToProduce), ref _quantityToProduce, value); }
+
+        private string _unit;
+        [XafDisplayName("Birim")]
+        public string Unit { get => _unit; set => SetPropertyValue(nameof(Unit), ref _unit, value); }
+
+        private DateTime _plannedStartDate;
+        [XafDisplayName("Planlanan Başlangıç")]
+        public DateTime PlannedStartDate { get => _plannedStartDate; set => SetPropertyValue(nameof(PlannedStartDate), ref _plannedStartDate, value); }
+
+        private DateTime _plannedEndDate;
+        [XafDisplayName("Planlanan Bitiş")]
+        public DateTime PlannedEndDate { get => _plannedEndDate; set => SetPropertyValue(nameof(PlannedEndDate), ref _plannedEndDate, value); }
+
+        private DateTime? _actualStartDate;
+        [XafDisplayName("Fiili Başlangıç")]
+        public DateTime? ActualStartDate { get => _actualStartDate; set => SetPropertyValue(nameof(ActualStartDate), ref _actualStartDate, value); }
+
+        private DateTime? _actualEndDate;
+        [XafDisplayName("Fiili Bitiş")]
+        public DateTime? ActualEndDate { get => _actualEndDate; set => SetPropertyValue(nameof(ActualEndDate), ref _actualEndDate, value); }
+
+        private double _quantityProduced;
+        [XafDisplayName("Üretilen Miktar")]
+        public double QuantityProduced { get => _quantityProduced; set => SetPropertyValue(nameof(QuantityProduced), ref _quantityProduced, value); }
+
+        private double _quantityScrapped;
+        [XafDisplayName("Fire Miktarı")]
+        public double QuantityScrapped { get => _quantityScrapped; set => SetPropertyValue(nameof(QuantityScrapped), ref _quantityScrapped, value); }
+
+        private ProductionOrderStatus _status;
+        [XafDisplayName("Durum")]
+        public ProductionOrderStatus Status { get => _status; set => SetPropertyValue(nameof(Status), ref _status, value); }
+
+        private BillOfMaterials _billOfMaterials;
+        [Association("BillOfMaterials-ProductionOrders")]
+        [XafDisplayName("Ürün Ağacı (Reçete)")]
+        public BillOfMaterials BillOfMaterials { get => _billOfMaterials; set => SetPropertyValue(nameof(BillOfMaterials), ref _billOfMaterials, value); }
+
+        private Routing _routing;
+        [Association("Routing-ProductionOrders")]
+        [XafDisplayName("Üretim Rotası")]
+        public Routing Routing { get => _routing; set => SetPropertyValue(nameof(Routing), ref _routing, value); }
+
+        private string _relatedSalesOrder;
+        [XafDisplayName("İlişkili Satış Siparişi")]
+        public string RelatedSalesOrder { get => _relatedSalesOrder; set => SetPropertyValue(nameof(RelatedSalesOrder), ref _relatedSalesOrder, value); }
+
+        [Association("PO-MaterialRequirements"), Aggregated]
+        [XafDisplayName("Gerekli Malzemeler")]
+        public XPCollection<ProductionOrderMaterialRequirement> MaterialRequirements => GetCollection<ProductionOrderMaterialRequirement>(nameof(MaterialRequirements));
+
+        [Association("PO-OperationLogs"), Aggregated]
+        [XafDisplayName("Üretim Operasyonları")]
+        public XPCollection<ProductionOrderOperationLog> OperationLogs => GetCollection<ProductionOrderOperationLog>(nameof(OperationLogs));
+
+        [Association("ProductionOrder-StockInbounds"), Aggregated] // Üretimden giriş hareketleri
+        [XafDisplayName("Stok Giriş Hareketleri (Mamul)")]
+        public XPCollection<StockTransaction> StockInbounds => GetCollection<StockTransaction>(nameof(StockInbounds));
+
+
+        public override void AfterConstruction() { base.AfterConstruction(); PlannedStartDate = DateTime.Now; Status = ProductionOrderStatus.Planned; QuantityToProduce = 1; }
+    }
+
+    public enum ProductionOrderStatus {
+        [Display(Name="Planlandı")] Planned = 0,
+        [Display(Name="Başlatıldı")] Started = 1,
+        [Display(Name="Devam Ediyor")] InProgress = 2,
+        [Display(Name="Tamamlandı")] Completed = 3,
+        [Display(Name="Kısmen Tamamlandı")] PartiallyCompleted = 4,
+        [Display(Name="İptal Edildi")] Cancelled = 5,
+        [Display(Name="Beklemede")] OnHold = 6
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ProductionOrderMaterialRequirement.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ProductionOrderMaterialRequirement.cs
@@ -1,0 +1,65 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DisplayName("Üretim Emri Malzeme İhtiyacı (XPO)")]
+    public class ProductionOrderMaterialRequirement : XPObject
+    {
+        public ProductionOrderMaterialRequirement(Session session) : base(session) { }
+
+        private ProductionOrder _productionOrder;
+        [Association("PO-MaterialRequirements")]
+        [Browsable(false)]
+        public ProductionOrder ProductionOrder { get => _productionOrder; set => SetPropertyValue(nameof(ProductionOrder), ref _productionOrder, value); }
+
+        private Material _material;
+        [Association("Material-ProductionOrderMaterialReq")]
+        [XafDisplayName("Malzeme")]
+        public Material Material {
+            get => _material;
+            set {
+                if(SetPropertyValue(nameof(Material), ref _material, value))
+                {
+                    if(!IsLoading && Material != null)
+                    {
+                        Unit = Material.BaseUnit;
+                    }
+                }
+            }
+        }
+
+        private double _requiredQuantityFromBom;
+        [XafDisplayName("Gerekli Miktar (BOM'dan)")]
+        public double RequiredQuantityFromBom { get => _requiredQuantityFromBom; set => SetPropertyValue(nameof(RequiredQuantityFromBom), ref _requiredQuantityFromBom, value); }
+
+        private double _plannedQuantity;
+        [XafDisplayName("Planlanan Miktar")]
+        public double PlannedQuantity { get => _plannedQuantity; set => SetPropertyValue(nameof(PlannedQuantity), ref _plannedQuantity, value); }
+
+        private double _actualQuantityUsed;
+        [XafDisplayName("Fiili Kullanılan Miktar")]
+        public double ActualQuantityUsed { get => _actualQuantityUsed; set => SetPropertyValue(nameof(ActualQuantityUsed), ref _actualQuantityUsed, value); }
+
+        private string _unit;
+        [XafDisplayName("Birim")]
+        public string Unit { get => _unit; set => SetPropertyValue(nameof(Unit), ref _unit, value); }
+
+        private Warehouse _warehouse;
+        [Association("Warehouse-ProductionOrderMaterialRequirements")]
+        [XafDisplayName("Depo")]
+        public Warehouse Warehouse { get => _warehouse; set => SetPropertyValue(nameof(Warehouse), ref _warehouse, value); }
+
+        [Association("ProductionOrderMaterialRequirement-StockOutbounds"), Aggregated] // Bu ihtiyaç için yapılan stok çıkışları
+        [XafDisplayName("Stok Çıkış Hareketleri (Sarf)")]
+        public XPCollection<StockTransaction> StockOutbounds => GetCollection<StockTransaction>(nameof(StockOutbounds));
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            PlannedQuantity = RequiredQuantityFromBom; // Başlangıçta eşit olabilir, fire vb. sonra eklenebilir.
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ProductionOrderOperationLog.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ProductionOrderOperationLog.cs
@@ -1,0 +1,79 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DisplayName("Üretim Operasyon Kaydı (XPO)")]
+    public class ProductionOrderOperationLog : XPObject
+    {
+        public ProductionOrderOperationLog(Session session) : base(session) { }
+
+        private ProductionOrder _productionOrder;
+        [Association("PO-OperationLogs")]
+        [Browsable(false)]
+        public ProductionOrder ProductionOrder { get => _productionOrder; set => SetPropertyValue(nameof(ProductionOrder), ref _productionOrder, value); }
+
+        private RoutingOperation _routingOperation;
+        [Association("RoutingOperation-ProductionOrderOperationLogs")]
+        [XafDisplayName("Rota Operasyonu")]
+        public RoutingOperation RoutingOperation {
+            get => _routingOperation;
+            set {
+                if(SetPropertyValue(nameof(RoutingOperation), ref _routingOperation, value))
+                {
+                    if(!IsLoading && RoutingOperation != null)
+                    {
+                        OperationName = RoutingOperation.OperationName;
+                        Workstation = RoutingOperation.Workstation;
+                    }
+                }
+            }
+        }
+
+        private string _operationName;
+        [XafDisplayName("Operasyon Adı")]
+        public string OperationName { get => _operationName; set => SetPropertyValue(nameof(OperationName), ref _operationName, value); }
+
+        private Workstation _workstation;
+        [Association("Workstation-ProductionOrderOperationLogs")]
+        [XafDisplayName("İş İstasyonu")]
+        public Workstation Workstation { get => _workstation; set => SetPropertyValue(nameof(Workstation), ref _workstation, value); }
+
+        private DateTime? _startTime;
+        [XafDisplayName("Başlangıç Zamanı")]
+        public DateTime? StartTime { get => _startTime; set => SetPropertyValue(nameof(StartTime), ref _startTime, value); }
+
+        private DateTime? _endTime;
+        [XafDisplayName("Bitiş Zamanı")]
+        public DateTime? EndTime { get => _endTime; set => SetPropertyValue(nameof(EndTime), ref _endTime, value); }
+
+        private double _quantityCompleted;
+        [XafDisplayName("Tamamlanan Miktar")]
+        public double QuantityCompleted { get => _quantityCompleted; set => SetPropertyValue(nameof(QuantityCompleted), ref _quantityCompleted, value); }
+
+        private double _quantityScrapped;
+        [XafDisplayName("Fire Miktarı")]
+        public double QuantityScrapped { get => _quantityScrapped; set => SetPropertyValue(nameof(QuantityScrapped), ref _quantityScrapped, value); }
+
+        private OperationLogStatus _status;
+        [XafDisplayName("Durum")]
+        public OperationLogStatus Status { get => _status; set => SetPropertyValue(nameof(Status), ref _status, value); }
+
+        private string _operatorName; // Veya Employee nesnesi
+        [XafDisplayName("Operatör")]
+        public string OperatorName { get => _operatorName; set => SetPropertyValue(nameof(OperatorName), ref _operatorName, value); }
+
+        public override void AfterConstruction() { base.AfterConstruction(); Status = OperationLogStatus.Pending; }
+    }
+
+    public enum OperationLogStatus
+    {
+        [Display(Name = "Beklemede")] Pending = 0,
+        [Display(Name = "Devam Ediyor")] InProgress = 1,
+        [Display(Name = "Tamamlandı")] Completed = 2,
+        [Display(Name = "Durduruldu")] Paused = 3
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/PurchaseOrder.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/PurchaseOrder.cs
@@ -1,0 +1,146 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Satın Alma")]
+    [DisplayName("Satınalma Siparişi (XPO)")]
+    public class PurchaseOrder : XPObject
+    {
+        public PurchaseOrder(Session session) : base(session) { }
+
+        private string _orderNumber;
+        [Size(20)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Sipariş Numarası")]
+        public string OrderNumber
+        {
+            get => _orderNumber;
+            set => SetPropertyValue(nameof(OrderNumber), ref _orderNumber, value);
+        }
+
+        private DateTime _orderDate;
+        [XafDisplayName("Sipariş Tarihi")]
+        public DateTime OrderDate
+        {
+            get => _orderDate;
+            set => SetPropertyValue(nameof(OrderDate), ref _orderDate, value);
+        }
+
+        private Supplier _supplier;
+        [Association("Supplier-PurchaseOrders")]
+        [XafDisplayName("Tedarikçi")]
+        public Supplier Supplier
+        {
+            get => _supplier;
+            set => SetPropertyValue(nameof(Supplier), ref _supplier, value);
+        }
+
+        private DateTime _expectedDeliveryDate;
+        [XafDisplayName("Beklenen Teslim Tarihi")]
+        public DateTime ExpectedDeliveryDate
+        {
+            get => _expectedDeliveryDate;
+            set => SetPropertyValue(nameof(ExpectedDeliveryDate), ref _expectedDeliveryDate, value);
+        }
+
+        private decimal _totalAmount;
+        [XafDisplayName("Toplam Tutar")]
+        public decimal TotalAmount
+        {
+            get => _totalAmount;
+            set => SetPropertyValue(nameof(TotalAmount), ref _totalAmount, value);
+        }
+
+        private string _currency;
+        [Size(3)]
+        [XafDisplayName("Para Birimi")]
+        public string Currency
+        {
+            get => _currency;
+            set => SetPropertyValue(nameof(Currency), ref _currency, value);
+        }
+
+        private PurchaseOrderStatus _status;
+        [XafDisplayName("Sipariş Durumu")]
+        public PurchaseOrderStatus Status
+        {
+            get => _status;
+            set => SetPropertyValue(nameof(Status), ref _status, value);
+        }
+
+        private string _notes;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Notlar")]
+        public string Notes
+        {
+            get => _notes;
+            set => SetPropertyValue(nameof(Notes), ref _notes, value);
+        }
+
+        [Association("PurchaseOrder-OrderItems"), Aggregated]
+        [XafDisplayName("Sipariş Kalemleri")]
+        public XPCollection<PurchaseOrderItem> OrderItems
+        {
+            get {
+                XPCollection<PurchaseOrderItem> items = GetCollection<PurchaseOrderItem>(nameof(OrderItems));
+                items.ListChanged += OrderItems_ListChanged;
+                return items;
+            }
+        }
+
+        private void OrderItems_ListChanged(object sender, ListChangedEventArgs e)
+        {
+            UpdateTotalAmount();
+        }
+
+        public void UpdateTotalAmount()
+        {
+            if (IsLoading || IsSaving) return;
+            decimal currentTotal = 0;
+            foreach (PurchaseOrderItem item in OrderItems)
+            {
+                currentTotal += item.LineTotalWithVatCalculated; // Kalemdeki hesaplanmış alanı kullan
+            }
+            TotalAmount = currentTotal;
+        }
+
+        [Association("PurchaseOrder-StockTransactions")]
+        [XafDisplayName("İlişkili Stok Hareketleri")]
+        public XPCollection<StockTransaction> StockTransactions => GetCollection<StockTransaction>(nameof(StockTransactions));
+
+        [Association("PurchaseOrder-Invoices")]
+        [XafDisplayName("İlişkili Alış Faturaları")]
+        public XPCollection<Invoice> Invoices => GetCollection<Invoice>(nameof(Invoices));
+
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            OrderDate = DateTime.Now;
+            ExpectedDeliveryDate = DateTime.Now.AddDays(7);
+            Currency = "TRY";
+            Status = PurchaseOrderStatus.Draft;
+        }
+
+        protected override void OnSaving()
+        {
+            UpdateTotalAmount(); // Kaydetmeden önce son bir kez toplamı güncelle
+            base.OnSaving();
+        }
+    }
+
+    public enum PurchaseOrderStatus {
+        [Display(Name="Taslak")] Draft=0,
+        [Display(Name="Onay Bekliyor")] PendingApproval=1,
+        [Display(Name="Onaylandı")] Approved = 2,
+        [Display(Name="Sipariş Verildi")] Ordered = 3,
+        [Display(Name="Kısmen Teslim Alındı")] PartiallyReceived = 4,
+        [Display(Name="Tamamı Teslim Alındı")] FullyReceived=5,
+        [Display(Name="İptal Edildi")] Cancelled=6
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/PurchaseOrderItem.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/PurchaseOrderItem.cs
@@ -1,0 +1,137 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DisplayName("Satınalma Sipariş Kalemi (XPO)")]
+    public class PurchaseOrderItem : XPObject
+    {
+        public PurchaseOrderItem(Session session) : base(session) { }
+
+        private PurchaseOrder _purchaseOrder;
+        [Association("PurchaseOrder-OrderItems")]
+        [Browsable(false)]
+        public PurchaseOrder PurchaseOrder
+        {
+            get => _purchaseOrder;
+            set => SetPropertyValue(nameof(PurchaseOrder), ref _purchaseOrder, value);
+        }
+
+        private Material _material; // Malzeme nesnesine referans
+        [XafDisplayName("Malzeme/Ürün")]
+        public Material Material
+        {
+            get => _material;
+            set {
+                if(SetPropertyValue(nameof(Material), ref _material, value))
+                {
+                    if(!IsLoading && Material != null)
+                    {
+                        ItemName = Material.MaterialName;
+                        Unit = Material.BaseUnit;
+                        // UnitPrice = Material.UnitCost; // Malzemenin maliyetini birim fiyata çekebilir
+                        if (PurchaseOrder != null) PurchaseOrder.UpdateTotalAmount();
+                    }
+                }
+            }
+        }
+
+        private string _itemName;
+        [Size(255)]
+        [XafDisplayName("Kalem Adı (Malzemeden gelir)")]
+        public string ItemName
+        {
+            get => _itemName;
+            set => SetPropertyValue(nameof(ItemName), ref _itemName, value);
+        }
+
+        private string _description;
+        [XafDisplayName("Açıklama")]
+        public string Description
+        {
+            get => _description;
+            set => SetPropertyValue(nameof(Description), ref _description, value);
+        }
+
+        private double _quantity;
+        [XafDisplayName("Miktar")]
+        public double Quantity
+        {
+            get => _quantity;
+            set {
+                if(SetPropertyValue(nameof(Quantity), ref _quantity, value)) {
+                    if (!IsLoading && PurchaseOrder != null) PurchaseOrder.UpdateTotalAmount();
+                }
+            }
+        }
+
+        private string _unit;
+        [Size(50)]
+        [XafDisplayName("Birim")]
+        public string Unit
+        {
+            get => _unit;
+            set => SetPropertyValue(nameof(Unit), ref _unit, value);
+        }
+
+        private decimal _unitPrice;
+        [XafDisplayName("Birim Fiyat")]
+        public decimal UnitPrice
+        {
+            get => _unitPrice;
+            set {
+                if(SetPropertyValue(nameof(UnitPrice), ref _unitPrice, value)) {
+                     if (!IsLoading && PurchaseOrder != null) PurchaseOrder.UpdateTotalAmount();
+                }
+            }
+        }
+
+        private decimal _vatRate;
+        [XafDisplayName("KDV Oranı (%)")]
+        public decimal VatRate
+        {
+            get => _vatRate;
+            set {
+                if(SetPropertyValue(nameof(VatRate), ref _vatRate, value)) {
+                    if (!IsLoading && PurchaseOrder != null) PurchaseOrder.UpdateTotalAmount();
+                }
+            }
+        }
+
+        [NonPersistent]
+        [XafDisplayName("Satır Tutarı (KDV'siz)")]
+        public decimal LineTotalCalculated
+        {
+            get { return (decimal)Quantity * UnitPrice; }
+        }
+
+        [NonPersistent]
+        [XafDisplayName("Satır KDV Tutarı")]
+        public decimal LineVatAmountCalculated
+        {
+            get { return LineTotalCalculated * (VatRate / 100); }
+        }
+
+        [NonPersistent]
+        [XafDisplayName("Satır Toplamı (KDV Dahil)")]
+        public decimal LineTotalWithVatCalculated
+        {
+            get { return LineTotalCalculated + LineVatAmountCalculated; }
+        }
+
+        [Association("PurchaseOrderItem-StockTransactions")]
+        [XafDisplayName("İlişkili Stok Hareketleri")]
+        public XPCollection<StockTransaction> StockTransactions => GetCollection<StockTransaction>(nameof(StockTransactions));
+
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            Unit = "Adet";
+            VatRate = 18;
+            Quantity = 1;
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/QualityCheck.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/QualityCheck.cs
@@ -1,0 +1,70 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Kalite Yönetimi")]
+    [DisplayName("Kalite Kontrol Kaydı (XPO)")]
+    public class QualityCheck : XPObject
+    {
+        public QualityCheck(Session session) : base(session) { }
+
+        private string _checkNumber;
+        [Size(20)]
+        [Indexed(Unique = true)] // Otomatik numara için Controller eklenecek
+        [XafDisplayName("Kontrol No")]
+        public string CheckNumber { get => _checkNumber; set => SetPropertyValue(nameof(CheckNumber), ref _checkNumber, value); }
+
+        private DateTime _checkDate;
+        [XafDisplayName("Kontrol Tarihi")]
+        public DateTime CheckDate { get => _checkDate; set => SetPropertyValue(nameof(CheckDate), ref _checkDate, value); }
+
+        private Material _material;
+        [Association("Material-QualityChecks")]
+        [XafDisplayName("Kontrol Edilen Ürün/Malzeme")]
+        public Material Material { get => _material; set => SetPropertyValue(nameof(Material), ref _material, value); }
+
+        private ProductionOrderOperationLog _productionOperation;
+        // ProductionOrderOperationLog'da QualityChecks koleksiyonu tanımlanabilir.
+        [XafDisplayName("Kontrol Edilen Süreç/Operasyon")]
+        public ProductionOrderOperationLog ProductionOperation { get => _productionOperation; set => SetPropertyValue(nameof(ProductionOperation), ref _productionOperation, value); }
+
+        private string _checkpoint;
+        [XafDisplayName("Kontrol Noktası/Aşaması")] // Giriş Kontrol, Proses Kontrol, Son Kontrol
+        public string Checkpoint { get => _checkpoint; set => SetPropertyValue(nameof(Checkpoint), ref _checkpoint, value); }
+
+        private Employee _checkedBy;
+        [Association("Employee-QualityChecksBy")]
+        [XafDisplayName("Kontrolü Yapan")]
+        public Employee CheckedBy { get => _checkedBy; set => SetPropertyValue(nameof(CheckedBy), ref _checkedBy, value); }
+
+        private QualityCheckResult _result;
+        [XafDisplayName("Sonuç")] // Uygun, Şartlı Kabul, Red
+        public QualityCheckResult Result { get => _result; set => SetPropertyValue(nameof(Result), ref _result, value); }
+
+        private string _remarks;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Açıklamalar")]
+        public string Remarks { get => _remarks; set => SetPropertyValue(nameof(Remarks), ref _remarks, value); }
+
+        [Association("QualityCheck-NonConformances")]
+        [XafDisplayName("İlişkili Uygunsuzluklar")]
+        public XPCollection<NonConformance> NonConformances => GetCollection<NonConformance>(nameof(NonConformances));
+
+        public override void AfterConstruction() {
+            base.AfterConstruction();
+            CheckDate = DateTime.Now;
+            Result = QualityCheckResult.Pending;
+        }
+    }
+    public enum QualityCheckResult {
+        [Display(Name="Beklemede")] Pending,
+        [Display(Name="Uygun")] Pass,
+        [Display(Name="Şartlı Kabul")] ConditionalPass,
+        [Display(Name="Red")] Fail
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Routing.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Routing.cs
@@ -1,0 +1,48 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("İmalat Yönetimi")]
+    [DisplayName("Üretim Rotası (XPO)")]
+    public class Routing : XPObject
+    {
+        public Routing(Session session) : base(session) { }
+
+        private string _routingCode;
+        [Size(50)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Rota Kodu")]
+        public string RoutingCode { get => _routingCode; set => SetPropertyValue(nameof(RoutingCode), ref _routingCode, value); }
+
+        private Material _product;
+        [Association("Material-RoutingProduct")]
+        [XafDisplayName("Üretilecek Ürün/Mamul")]
+        public Material Product { get => _product; set => SetPropertyValue(nameof(Product), ref _product, value); }
+
+        private string _description;
+        [XafDisplayName("Açıklama")]
+        public string Description { get => _description; set => SetPropertyValue(nameof(Description), ref _description, value); }
+
+        private string _version;
+        [XafDisplayName("Versiyon")]
+        public string Version { get => _version; set => SetPropertyValue(nameof(Version), ref _version, value); }
+
+        private bool _isActive;
+        [XafDisplayName("Aktif Rota")]
+        public bool IsActive { get => _isActive; set => SetPropertyValue(nameof(IsActive), ref _isActive, value); }
+
+        [Association("Routing-Operations"), Aggregated]
+        [XafDisplayName("Rota Operasyonları")]
+        public XPCollection<RoutingOperation> Operations => GetCollection<RoutingOperation>(nameof(Operations));
+
+        [Association("Routing-ProductionOrders")]
+        [XafDisplayName("Kullanıldığı Üretim Emirleri")]
+        public XPCollection<ProductionOrder> ProductionOrders => GetCollection<ProductionOrder>(nameof(ProductionOrders));
+
+        public override void AfterConstruction() { base.AfterConstruction(); IsActive = true; Version = "1.0"; }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/RoutingOperation.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/RoutingOperation.cs
@@ -1,0 +1,58 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DisplayName("Rota Operasyonu (XPO)")]
+    public class RoutingOperation : XPObject
+    {
+        public RoutingOperation(Session session) : base(session) { }
+
+        private Routing _routing;
+        [Association("Routing-Operations")]
+        [Browsable(false)]
+        public Routing Routing { get => _routing; set => SetPropertyValue(nameof(Routing), ref _routing, value); }
+
+        private int _sequence;
+        [XafDisplayName("Sıra No")]
+        public int Sequence { get => _sequence; set => SetPropertyValue(nameof(Sequence), ref _sequence, value); }
+
+        private string _operationName;
+        [Size(255)]
+        [XafDisplayName("Operasyon Adı")]
+        public string OperationName { get => _operationName; set => SetPropertyValue(nameof(OperationName), ref _operationName, value); }
+
+        private string _description;
+        [XafDisplayName("Açıklama")]
+        public string Description { get => _description; set => SetPropertyValue(nameof(Description), ref _description, value); }
+
+        private Workstation _workstation;
+        [Association("Workstation-RoutingOperations")]
+        [XafDisplayName("İş İstasyonu")]
+        public Workstation Workstation { get => _workstation; set => SetPropertyValue(nameof(Workstation), ref _workstation, value); }
+
+        private int _setupTime;
+        [XafDisplayName("Hazırlık Süresi (dk)")]
+        public int SetupTime { get => _setupTime; set => SetPropertyValue(nameof(SetupTime), ref _setupTime, value); }
+
+        private double _processingTimePerUnit;
+        [XafDisplayName("İşlem Süresi (dk/birim)")]
+        public double ProcessingTimePerUnit { get => _processingTimePerUnit; set => SetPropertyValue(nameof(ProcessingTimePerUnit), ref _processingTimePerUnit, value); }
+
+        private int _waitTime;
+        [XafDisplayName("Bekleme Süresi (dk)")]
+        public int WaitTime { get => _waitTime; set => SetPropertyValue(nameof(WaitTime), ref _waitTime, value); }
+
+        [Association("RoutingOperation-ProductionOrderOperationLogs")]
+        [XafDisplayName("Üretim Operasyon Kayıtları")]
+        public XPCollection<ProductionOrderOperationLog> ProductionOrderOperationLogs => GetCollection<ProductionOrderOperationLog>(nameof(ProductionOrderOperationLogs));
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            Sequence = (Routing?.Operations.Count + 1) ?? 1;
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/SalesOpportunity.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/SalesOpportunity.cs
@@ -1,0 +1,133 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+using DevExpress.Persistent.BaseImpl.Xpo; // PermissionPolicyUser için
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Satış Pazarlama")]
+    [DisplayName("Satış Fırsatı (XPO)")]
+    public class SalesOpportunity : XPObject
+    {
+        public SalesOpportunity(Session session) : base(session) { }
+
+        private string _opportunityCode;
+        [Size(20)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Fırsat Kodu")]
+        public string OpportunityCode
+        {
+            get => _opportunityCode;
+            set => SetPropertyValue(nameof(OpportunityCode), ref _opportunityCode, value);
+        }
+
+        private string _opportunityName;
+        [Size(255)]
+        [XafDisplayName("Fırsat Adı")]
+        public string OpportunityName
+        {
+            get => _opportunityName;
+            set => SetPropertyValue(nameof(OpportunityName), ref _opportunityName, value);
+        }
+
+        private Customer _customer;
+        [Association("Customer-SalesOpportunities")]
+        [XafDisplayName("Müşteri")]
+        public Customer Customer
+        {
+            get => _customer;
+            set => SetPropertyValue(nameof(Customer), ref _customer, value);
+        }
+
+        private Lead _lead;
+        [Association("Lead-SalesOpportunities")]
+        [XafDisplayName("Potansiyel Müşteri")]
+        public Lead Lead
+        {
+            get => _lead;
+            set => SetPropertyValue(nameof(Lead), ref _lead, value);
+        }
+
+        private DateTime _estimatedCloseDate;
+        [XafDisplayName("Tahmini Kapanış Tarihi")]
+        public DateTime EstimatedCloseDate
+        {
+            get => _estimatedCloseDate;
+            set => SetPropertyValue(nameof(EstimatedCloseDate), ref _estimatedCloseDate, value);
+        }
+
+        private decimal _estimatedAmount;
+        [XafDisplayName("Fırsat Tutarı")]
+        public decimal EstimatedAmount
+        {
+            get => _estimatedAmount;
+            set => SetPropertyValue(nameof(EstimatedAmount), ref _estimatedAmount, value);
+        }
+
+        private int _probability;
+        [XafDisplayName("Olasılık (%)")]
+        public int Probability
+        {
+            get => _probability;
+            set => SetPropertyValue(nameof(Probability), ref _probability, value);
+        }
+
+        private OpportunityStage _stage;
+        [XafDisplayName("Aşama")]
+        public OpportunityStage Stage
+        {
+            get => _stage;
+            set => SetPropertyValue(nameof(Stage), ref _stage, value);
+        }
+
+        private PermissionPolicyUser _salesRepresentative; // XPO User
+        [XafDisplayName("Sorumlu Satışçı")]
+        public PermissionPolicyUser SalesRepresentative
+        {
+            get => _salesRepresentative;
+            set => SetPropertyValue(nameof(SalesRepresentative), ref _salesRepresentative, value);
+        }
+
+        private string _description;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Açıklama")]
+        public string Description
+        {
+            get => _description;
+            set => SetPropertyValue(nameof(Description), ref _description, value);
+        }
+
+        private DateTime _createdDate;
+        [XafDisplayName("Oluşturulma Tarihi")]
+        public DateTime CreatedDate
+        {
+            get => _createdDate;
+            set => SetPropertyValue(nameof(CreatedDate), ref _createdDate, value);
+        }
+
+        [Association("SalesOpportunity-Offers")]
+        [XafDisplayName("Teklifler")]
+        public XPCollection<Offer> Offers => GetCollection<Offer>(nameof(Offers));
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            CreatedDate = DateTime.Now;
+            Stage = OpportunityStage.Qualification;
+            EstimatedCloseDate = DateTime.Now.AddMonths(1);
+        }
+    }
+
+    public enum OpportunityStage
+    {
+        [Display(Name = "Niteleniyor")] Qualification = 0,
+        [Display(Name = "İhtiyaç Analizi")] NeedsAnalysis = 1,
+        [Display(Name = "Teklif Aşaması")] Proposal = 2,
+        [Display(Name = "Müzakere")] Negotiation = 3,
+        [Display(Name = "Kazanıldı")] Won = 4,
+        [Display(Name = "Kaybedildi")] Lost = 5
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ServiceContract.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ServiceContract.cs
@@ -1,0 +1,69 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Hizmet Yönetimi")]
+    [DisplayName("Hizmet Sözleşmesi (XPO)")]
+    public class ServiceContract : XPObject
+    {
+        public ServiceContract(Session session) : base(session) { }
+
+        private string _contractNumber;
+        [Size(20)]
+        [Indexed(Unique = true)] // Otomatik numara için Controller eklenecek
+        [XafDisplayName("Sözleşme Numarası")]
+        public string ContractNumber { get => _contractNumber; set => SetPropertyValue(nameof(ContractNumber), ref _contractNumber, value); }
+
+        private Customer _customer;
+        [Association("Customer-ServiceContracts")]
+        [XafDisplayName("Müşteri")]
+        public Customer Customer { get => _customer; set => SetPropertyValue(nameof(Customer), ref _customer, value); }
+
+        private DateTime _startDate;
+        [XafDisplayName("Başlangıç Tarihi")]
+        public DateTime StartDate { get => _startDate; set => SetPropertyValue(nameof(StartDate), ref _startDate, value); }
+
+        private DateTime _endDate;
+        [XafDisplayName("Bitiş Tarihi")]
+        public DateTime EndDate { get => _endDate; set => SetPropertyValue(nameof(EndDate), ref _endDate, value); }
+
+        private decimal _contractAmount;
+        [XafDisplayName("Sözleşme Tutarı")]
+        // Bu alan, ContractItems'dan hesaplanabilir veya manuel girilebilir.
+        // PersistentAlias ile: [PersistentAlias("ContractItems.Sum(AgreedPrice * Quantity)")]
+        public decimal ContractAmount { get => _contractAmount; set => SetPropertyValue(nameof(ContractAmount), ref _contractAmount, value); }
+
+        private string _description;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Açıklama")]
+        public string Description { get => _description; set => SetPropertyValue(nameof(Description), ref _description, value); }
+
+        private ContractStatus _status;
+        [XafDisplayName("Durum")]
+        public ContractStatus Status { get => _status; set => SetPropertyValue(nameof(Status), ref _status, value); }
+
+        [Association("ServiceContract-ContractItems"), Aggregated]
+        [XafDisplayName("Sözleşme Kapsamındaki Hizmetler")]
+        public XPCollection<ServiceContractItem> ContractItems => GetCollection<ServiceContractItem>(nameof(ContractItems));
+
+        public override void AfterConstruction() {
+            base.AfterConstruction();
+            StartDate = DateTime.Now;
+            EndDate = DateTime.Now.AddYears(1);
+            Status = ContractStatus.Active;
+        }
+    }
+
+    public enum ContractStatus
+    {
+        [Display(Name = "Taslak")] Draft = 0,
+        [Display(Name = "Aktif")] Active = 1,
+        [Display(Name = "Süresi Doldu")] Expired = 2,
+        [Display(Name = "İptal Edildi")] Cancelled = 3
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ServiceContractItem.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ServiceContractItem.cs
@@ -1,0 +1,52 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DisplayName("Sözleşme Kapsamındaki Hizmet (XPO)")]
+    public class ServiceContractItem : XPObject
+    {
+        public ServiceContractItem(Session session) : base(session) { }
+
+        private ServiceContract _serviceContract;
+        [Association("ServiceContract-ContractItems")]
+        [Browsable(false)]
+        public ServiceContract ServiceContract { get => _serviceContract; set => SetPropertyValue(nameof(ServiceContract), ref _serviceContract, value); }
+
+        private ServiceDefinition _serviceDefinition;
+        [Association("ServiceDefinition-ContractItems")]
+        [XafDisplayName("Hizmet")]
+        public ServiceDefinition ServiceDefinition {
+            get => _serviceDefinition;
+            set {
+                if(SetPropertyValue(nameof(ServiceDefinition), ref _serviceDefinition, value))
+                {
+                    if(!IsLoading && ServiceDefinition != null)
+                    {
+                        // Hizmet seçildiğinde anlaşılan fiyatı, hizmet tanımındaki fiyattan alabiliriz.
+                        AgreedPrice = ServiceDefinition.UnitPrice;
+                    }
+                }
+            }
+        }
+
+        private int _quantity;
+        [XafDisplayName("Adet/Miktar")]
+        public int Quantity { get => _quantity; set => SetPropertyValue(nameof(Quantity), ref _quantity, value); }
+
+        private decimal _agreedPrice;
+        [XafDisplayName("Anlaşılan Fiyat")]
+        public decimal AgreedPrice { get => _agreedPrice; set => SetPropertyValue(nameof(AgreedPrice), ref _agreedPrice, value); }
+
+        // Sözleşme toplamını etkileyecekse, bu property'nin OnChanged'inde ServiceContract.UpdateTotals() gibi bir metod çağrılabilir.
+        // Veya ServiceContract.ContractAmount PersistentAlias ile hesaplanabilir.
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            Quantity = 1;
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ServiceDefinition.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ServiceDefinition.cs
@@ -1,0 +1,64 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Hizmet Yönetimi")]
+    [DisplayName("Hizmet Tanımı (XPO)")]
+    public class ServiceDefinition : XPObject
+    {
+        public ServiceDefinition(Session session) : base(session) { }
+
+        private string _serviceCode;
+        [Size(50)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Hizmet Kodu")]
+        public string ServiceCode { get => _serviceCode; set => SetPropertyValue(nameof(ServiceCode), ref _serviceCode, value); }
+
+        private string _serviceName;
+        [XafDisplayName("Hizmet Adı")]
+        public string ServiceName { get => _serviceName; set => SetPropertyValue(nameof(ServiceName), ref _serviceName, value); }
+
+        private string _description;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Açıklama")]
+        public string Description { get => _description; set => SetPropertyValue(nameof(Description), ref _description, value); }
+
+        private string _category;
+        [XafDisplayName("Kategori")]
+        public string Category { get => _category; set => SetPropertyValue(nameof(Category), ref _category, value); }
+
+        private decimal _unitPrice;
+        [XafDisplayName("Birim Fiyat")]
+        public decimal UnitPrice { get => _unitPrice; set => SetPropertyValue(nameof(UnitPrice), ref _unitPrice, value); }
+
+        private double _duration;
+        [XafDisplayName("Süre")] // Hizmetin tipik süresi
+        public double Duration { get => _duration; set => SetPropertyValue(nameof(Duration), ref _duration, value); }
+
+        private DurationUnitType _durationUnit;
+        [XafDisplayName("Süre Birimi")]
+        public DurationUnitType DurationUnit { get => _durationUnit; set => SetPropertyValue(nameof(DurationUnit), ref _durationUnit, value); }
+
+        [Association("ServiceDefinition-ContractItems")]
+        [XafDisplayName("Kullanıldığı Sözleşme Kalemleri")]
+        public XPCollection<ServiceContractItem> ServiceContractItems => GetCollection<ServiceContractItem>(nameof(ServiceContractItems));
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            DurationUnit = DurationUnitType.Hour;
+        }
+    }
+
+    public enum DurationUnitType
+    {
+        [Display(Name = "Saat")] Hour = 0,
+        [Display(Name = "Gün")] Day = 1,
+        [Display(Name = "Ay")] Month = 2,
+        [Display(Name = "Yıl")] Year = 3
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ServiceReport.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ServiceReport.cs
@@ -1,0 +1,63 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Teknik Servis")]
+    [DisplayName("Servis Raporu (XPO)")]
+    public class ServiceReport : XPObject
+    {
+        public ServiceReport(Session session) : base(session) { }
+
+        private string _reportNumber;
+        [Size(20)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Rapor Numarası")]
+        public string ReportNumber { get => _reportNumber; set => SetPropertyValue(nameof(ReportNumber), ref _reportNumber, value); }
+
+        private ServiceTicket _serviceTicket;
+        // ServiceTicket'taki Association ile eşleşmeli.
+        // Eğer ServiceTicket silindiğinde bu raporun da silinmesini istiyorsak,
+        // ServiceTicket tarafındaki Association'da Aggregated olmalı.
+        // Ya da burada Association'ı tanımlayıp, ServiceTicket'taki property'i bu Association'a bağlarız.
+        [Association("ServiceTicket-ServiceReportOneToOne")]
+        [XafDisplayName("İlişkili Servis Talebi")]
+        public ServiceTicket ServiceTicket
+        {
+            get => _serviceTicket;
+            set => SetPropertyValue(nameof(ServiceTicket), ref _serviceTicket, value);
+        }
+
+        private DateTime _reportDate;
+        [XafDisplayName("Rapor Tarihi")]
+        public DateTime ReportDate { get => _reportDate; set => SetPropertyValue(nameof(ReportDate), ref _reportDate, value); }
+
+        private string _technicianNotes;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Yapılan İşlemler / Teknisyen Notları")]
+        public string TechnicianNotes { get => _technicianNotes; set => SetPropertyValue(nameof(TechnicianNotes), ref _technicianNotes, value); }
+
+        private string _usedMaterials;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Kullanılan Malzemeler")] // Daha sonra XPCollection<MaterialUsage> gibi bir yapıya dönüşebilir
+        public string UsedMaterials { get => _usedMaterials; set => SetPropertyValue(nameof(UsedMaterials), ref _usedMaterials, value); }
+
+        private double _totalHoursWorked;
+        [XafDisplayName("Toplam Çalışma Süresi (saat)")]
+        public double TotalHoursWorked { get => _totalHoursWorked; set => SetPropertyValue(nameof(TotalHoursWorked), ref _totalHoursWorked, value); }
+
+        private bool _customerApproved;
+        [XafDisplayName("Müşteri Onayı")]
+        public bool CustomerApproved { get => _customerApproved; set => SetPropertyValue(nameof(CustomerApproved), ref _customerApproved, value); }
+
+        private string _customerApproverName;
+        [XafDisplayName("Müşteri Adı Soyadı (Onaylayan)")]
+        public string CustomerApproverName { get => _customerApproverName; set => SetPropertyValue(nameof(CustomerApproverName), ref _customerApproverName, value); }
+
+        public override void AfterConstruction() { base.AfterConstruction(); ReportDate = DateTime.Now; }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ServiceTicket.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ServiceTicket.cs
@@ -1,0 +1,120 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+using DevExpress.Persistent.BaseImpl.Xpo; // PermissionPolicyUser için
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Teknik Servis")]
+    [DisplayName("Servis Talebi/İş Emri (XPO)")]
+    public class ServiceTicket : XPObject
+    {
+        public ServiceTicket(Session session) : base(session) { }
+
+        private string _ticketNumber;
+        [Size(20)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Servis Talep No")]
+        public string TicketNumber { get => _ticketNumber; set => SetPropertyValue(nameof(TicketNumber), ref _ticketNumber, value); }
+
+        private DateTime _reportedDate;
+        [XafDisplayName("Bildirim Tarihi")]
+        public DateTime ReportedDate { get => _reportedDate; set => SetPropertyValue(nameof(ReportedDate), ref _reportedDate, value); }
+
+        private Customer _customer;
+        [Association("Customer-ServiceTickets")]
+        [XafDisplayName("Müşteri")]
+        public Customer Customer { get => _customer; set => SetPropertyValue(nameof(Customer), ref _customer, value); }
+
+        private Equipment _equipment;
+        [Association("Equipment-ServiceTickets")]
+        [XafDisplayName("Ekipman")]
+        public Equipment Equipment { get => _equipment; set => SetPropertyValue(nameof(Equipment), ref _equipment, value); }
+
+        private string _issueDescription;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Sorun Açıklaması")]
+        public string IssueDescription { get => _issueDescription; set => SetPropertyValue(nameof(IssueDescription), ref _issueDescription, value); }
+
+        private ServiceTicketType _ticketType;
+        [XafDisplayName("Talep Tipi")]
+        public ServiceTicketType TicketType { get => _ticketType; set => SetPropertyValue(nameof(TicketType), ref _ticketType, value); }
+
+        private ServiceTicketPriority _priority;
+        [XafDisplayName("Öncelik")]
+        public ServiceTicketPriority Priority { get => _priority; set => SetPropertyValue(nameof(Priority), ref _priority, value); }
+
+        private ServiceTicketStatus _status;
+        [XafDisplayName("Durum")]
+        public ServiceTicketStatus Status { get => _status; set => SetPropertyValue(nameof(Status), ref _status, value); }
+
+        private PermissionPolicyUser _assignedTechnician; // XPO User
+        [XafDisplayName("Atanan Teknisyen")]
+        public PermissionPolicyUser AssignedTechnician { get => _assignedTechnician; set => SetPropertyValue(nameof(AssignedTechnician), ref _assignedTechnician, value); }
+
+        private DateTime? _scheduledDate;
+        [XafDisplayName("Planlanan Servis Tarihi")]
+        public DateTime? ScheduledDate { get => _scheduledDate; set => SetPropertyValue(nameof(ScheduledDate), ref _scheduledDate, value); }
+
+        private DateTime? _completionDate;
+        [XafDisplayName("Tamamlanma Tarihi")]
+        public DateTime? CompletionDate { get => _completionDate; set => SetPropertyValue(nameof(CompletionDate), ref _completionDate, value); }
+
+        // ServiceReport ile bire-bir ilişki için. ServiceReport'ta da ServiceTicket'a referans olacak.
+        // Eğer ServiceReport silindiğinde ServiceTicket kalmalıysa Aggregated kullanmayız.
+        // ServiceTicket silindiğinde ServiceReport silinsin istiyorsak ServiceReport'taki Association'da Aggregated olur.
+        // Ya da ServiceReport'u ServiceTicket'ın bir parçası gibi yönetmek için burada Aggregated kullanılabilir.
+        private ServiceReport _serviceReport;
+        [Association("ServiceTicket-ServiceReportOneToOne"), Aggregated] // Bir talep bir rapor (genellikle)
+        [XafDisplayName("Servis Raporu")]
+        public ServiceReport ServiceReport
+        {
+            get => _serviceReport;
+            set => SetPropertyValue(nameof(ServiceReport), ref _serviceReport, value);
+        }
+
+        [Association("ServiceTicket-MaintenanceLogs")]
+        [XafDisplayName("İlişkili Bakım Kayıtları")]
+        public XPCollection<MaintenanceLog> MaintenanceLogs => GetCollection<MaintenanceLog>(nameof(MaintenanceLogs));
+
+
+        public override void AfterConstruction() {
+            base.AfterConstruction();
+            ReportedDate = DateTime.Now;
+            TicketType = ServiceTicketType.Repair;
+            Priority = ServiceTicketPriority.Medium;
+            Status = ServiceTicketStatus.Open;
+        }
+    }
+
+    public enum ServiceTicketType
+    {
+        [Display(Name = "Arıza Onarım")] Repair = 0,
+        [Display(Name = "Periyodik Bakım")] Maintenance = 1,
+        [Display(Name = "Kurulum")] Installation = 2,
+        [Display(Name = "Danışmanlık")] Consultation = 3,
+        [Display(Name = "Diğer")] Other = 4
+    }
+
+    public enum ServiceTicketPriority
+    {
+        [Display(Name = "Düşük")] Low = 0,
+        [Display(Name = "Orta")] Medium = 1,
+        [Display(Name = "Yüksek")] High = 2,
+        [Display(Name = "Acil")] Urgent = 3
+    }
+
+    public enum ServiceTicketStatus
+    {
+        [Display(Name = "Açık")] Open = 0,
+        [Display(Name = "Atandı")] Assigned = 1,
+        [Display(Name = "Devam Ediyor")] InProgress = 2,
+        [Display(Name = "Beklemede (Müşteri/Parça)")] OnHold = 3,
+        [Display(Name = "Çözüldü")] Resolved = 4,
+        [Display(Name = "Kapatıldı")] Closed = 5,
+        [Display(Name = "İptal Edildi")] Cancelled = 6
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Shipment.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Shipment.cs
@@ -1,0 +1,117 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Sevkiyat Yönetimi")]
+    [DisplayName("Sevkiyat/İrsaliye (XPO)")]
+    public class Shipment : XPObject
+    {
+        public Shipment(Session session) : base(session) { }
+
+        private string _shipmentNumber;
+        [Size(20)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Sevkiyat/İrsaliye No")]
+        public string ShipmentNumber
+        {
+            get => _shipmentNumber;
+            set => SetPropertyValue(nameof(ShipmentNumber), ref _shipmentNumber, value);
+        }
+
+        private DateTime _shipmentDate;
+        [XafDisplayName("Sevkiyat Tarihi")]
+        public DateTime ShipmentDate
+        {
+            get => _shipmentDate;
+            set => SetPropertyValue(nameof(ShipmentDate), ref _shipmentDate, value);
+        }
+
+        private Customer _customer;
+        [Association("Customer-Shipments")]
+        [XafDisplayName("Müşteri")]
+        public Customer Customer
+        {
+            get => _customer;
+            set => SetPropertyValue(nameof(Customer), ref _customer, value);
+        }
+
+        private Offer _relatedOffer;
+        // Offer'da Shipment için bir koleksiyon tanımlamadıysak buradaki Association tek yönlü kalabilir.
+        // Eğer Offer'da da Shipments koleksiyonu olacaksa çift yönlü Association tanımlanır.
+        [XafDisplayName("İlişkili Satış Teklifi")]
+        public Offer RelatedOffer
+        {
+            get => _relatedOffer;
+            set => SetPropertyValue(nameof(RelatedOffer), ref _relatedOffer, value);
+        }
+
+        private string _shippingAddress;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Teslimat Adresi")]
+        public string ShippingAddress
+        {
+            get => _shippingAddress;
+            set => SetPropertyValue(nameof(ShippingAddress), ref _shippingAddress, value);
+        }
+
+        private string _carrier;
+        [XafDisplayName("Taşıyıcı Firma")]
+        public string Carrier
+        {
+            get => _carrier;
+            set => SetPropertyValue(nameof(Carrier), ref _carrier, value);
+        }
+
+        private string _trackingNumber;
+        [XafDisplayName("Takip Numarası")]
+        public string TrackingNumber
+        {
+            get => _trackingNumber;
+            set => SetPropertyValue(nameof(TrackingNumber), ref _trackingNumber, value);
+        }
+
+        private ShipmentStatus _status;
+        [XafDisplayName("Durum")]
+        public ShipmentStatus Status
+        {
+            get => _status;
+            set => SetPropertyValue(nameof(Status), ref _status, value);
+        }
+
+        private string _notes;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Notlar")]
+        public string Notes
+        {
+            get => _notes;
+            set => SetPropertyValue(nameof(Notes), ref _notes, value);
+        }
+
+        [Association("Shipment-ShipmentItems"), Aggregated]
+        [XafDisplayName("Sevkiyat Kalemleri")]
+        public XPCollection<ShipmentItem> ShipmentItems => GetCollection<ShipmentItem>(nameof(ShipmentItems));
+
+        [Association("Shipment-Invoices")] // Bir sevkiyattan birden fazla fatura kesilebilir (kısmi faturalama)
+        [XafDisplayName("İlişkili Faturalar")]
+        public XPCollection<Invoice> Invoices => GetCollection<Invoice>(nameof(Invoices));
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            ShipmentDate = DateTime.Now;
+            Status = ShipmentStatus.Preparing;
+        }
+    }
+
+    public enum ShipmentStatus {
+        [Display(Name="Hazırlanıyor")] Preparing = 0,
+        [Display(Name="Sevk Edildi")] Shipped = 1,
+        [Display(Name="Teslim Edildi")] Delivered = 2,
+        [Display(Name="İptal Edildi")] Cancelled = 3
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ShipmentItem.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/ShipmentItem.cs
@@ -1,0 +1,91 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DisplayName("Sevkiyat Kalemi (XPO)")]
+    public class ShipmentItem : XPObject
+    {
+        public ShipmentItem(Session session) : base(session) { }
+
+        private Shipment _shipment;
+        [Association("Shipment-ShipmentItems")]
+        [Browsable(false)]
+        public Shipment Shipment
+        {
+            get => _shipment;
+            set => SetPropertyValue(nameof(Shipment), ref _shipment, value);
+        }
+
+        private Material _material;
+        [Association("Material-ShipmentItems")]
+        [XafDisplayName("Malzeme/Ürün")]
+        public Material Material
+        {
+            get => _material;
+            set {
+                if (SetPropertyValue(nameof(Material), ref _material, value))
+                {
+                    if (!IsLoading && Material != null)
+                    {
+                        Description = Material.MaterialName;
+                        Unit = Material.BaseUnit;
+                    }
+                }
+            }
+        }
+
+        private string _description;
+        [XafDisplayName("Açıklama")]
+        public string Description
+        {
+            get => _description;
+            set => SetPropertyValue(nameof(Description), ref _description, value);
+        }
+
+        private double _quantity;
+        [XafDisplayName("Miktar")]
+        public double Quantity
+        {
+            get => _quantity;
+            set => SetPropertyValue(nameof(Quantity), ref _quantity, value);
+        }
+
+        private string _unit;
+        [Size(50)]
+        [XafDisplayName("Birim")]
+        public string Unit
+        {
+            get => _unit;
+            set => SetPropertyValue(nameof(Unit), ref _unit, value);
+        }
+
+        private Warehouse _warehouse;
+        [Association("Warehouse-ShipmentItems")]
+        [XafDisplayName("Depo")]
+        public Warehouse Warehouse
+        {
+            get => _warehouse;
+            set => SetPropertyValue(nameof(Warehouse), ref _warehouse, value);
+        }
+
+        [Association("ShipmentItem-StockTransactions"), Aggregated] // Bir sevkiyat kalemi bir stok hareketi oluşturur (çıkış)
+        [XafDisplayName("İlişkili Stok Hareketi")]
+        public StockTransaction StockTransaction
+        {
+            // Tek bir stok hareketi olacağı için XPCollection değil, tekil referans.
+            // Bu, sevkiyat onaylandığında veya "Sevk Edildi" durumuna geldiğinde oluşturulmalı.
+            // Şimdilik sadece property olarak tanımlayalım. Otomatik oluşturma Controller ile yapılır.
+            get => GetPropertyValue<StockTransaction>(nameof(StockTransaction));
+            set => SetPropertyValue(nameof(StockTransaction), value);
+        }
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            Quantity = 1;
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/StockCount.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/StockCount.cs
@@ -1,0 +1,92 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Depo Yönetimi")]
+    [DisplayName("Stok Sayımı (XPO)")]
+    public class StockCount : XPObject
+    {
+        public StockCount(Session session) : base(session) { }
+
+        private string _countNumber;
+        [Size(20)]
+        [Indexed(Unique = true)] // Otomatik numara için Controller eklenecek
+        [XafDisplayName("Sayım Numarası")]
+        public string CountNumber { get => _countNumber; set => SetPropertyValue(nameof(CountNumber), ref _countNumber, value); }
+
+        private DateTime _countDate;
+        [XafDisplayName("Sayım Tarihi")]
+        public DateTime CountDate { get => _countDate; set => SetPropertyValue(nameof(CountDate), ref _countDate, value); }
+
+        private Warehouse _warehouse;
+        [Association("Warehouse-StockCounts")]
+        [XafDisplayName("Depo")]
+        public Warehouse Warehouse { get => _warehouse; set => SetPropertyValue(nameof(Warehouse), ref _warehouse, value); }
+
+        private Employee _countedBy;
+        [Association("Employee-StockCountsBy")]
+        [XafDisplayName("Sayan Kişi")]
+        public Employee CountedBy { get => _countedBy; set => SetPropertyValue(nameof(CountedBy), ref _countedBy, value); }
+
+        private StockCountStatus _status;
+        [XafDisplayName("Durum")]
+        public StockCountStatus Status { get => _status; set => SetPropertyValue(nameof(Status), ref _status, value); }
+
+        private string _notes;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Notlar")]
+        public string Notes { get => _notes; set => SetPropertyValue(nameof(Notes), ref _notes, value); }
+
+        [Association("StockCount-CountItems"), Aggregated]
+        [XafDisplayName("Sayım Kalemleri")]
+        public XPCollection<StockCountItem> CountItems => GetCollection<StockCountItem>(nameof(CountItems));
+
+        public override void AfterConstruction() {
+            base.AfterConstruction();
+            CountDate = DateTime.Now;
+            Status = StockCountStatus.Planned;
+        }
+
+        // Sayım kalemleri yüklendikten veya değiştirildikten sonra çağrılacak bir Action (Controller ile)
+        // Bu Action, CountItems'taki her bir Material için SystemQuantity'yi o anki stoktan çekebilir.
+        public void LoadSystemQuantities()
+        {
+            if (Warehouse == null) return;
+            foreach(var item in CountItems)
+            {
+                if(item.Material != null)
+                {
+                    // Depo bazlı stok miktarını almak için daha karmaşık bir sorgu gerekebilir.
+                    // Şimdilik Material.TotalStockQuantity'yi (tüm depolardaki toplam) alalım,
+                    // Bu, depo bazlı sayım için doğru olmayacaktır.
+                    // Doğrusu: item.Material.StockTransactions.Where(st => st.Warehouse == this.Warehouse).Sum(st => st.Quantity);
+                    // Ancak bu PersistentAlias içinde daha zor ifade edilir, bu yüzden bir metodla yapıyoruz.
+
+                    double qtyInWarehouse = 0;
+                    var transactionsInWarehouse = new XPQuery<StockTransaction>(Session)
+                        .Where(st => st.Material == item.Material && st.Warehouse == this.Warehouse);
+
+                    if(transactionsInWarehouse.Any())
+                    {
+                        qtyInWarehouse = transactionsInWarehouse.Sum(st => st.Quantity);
+                    }
+                    item.SystemQuantity = qtyInWarehouse;
+                }
+            }
+        }
+    }
+
+    public enum StockCountStatus
+    {
+        [Display(Name = "Planlandı")] Planned = 0,
+        [Display(Name = "Devam Ediyor")] InProgress = 1,
+        [Display(Name = "Tamamlandı")] Completed = 2, // Sayım bitti, farklar hesaplandı
+        [Display(Name = "Onaylandı")] Approved = 3, // Farklar stok hareketlerine işlendi
+        [Display(Name = "İptal Edildi")] Cancelled = 4
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/StockCountItem.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/StockCountItem.cs
@@ -1,0 +1,71 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System; // Convert için
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DisplayName("Stok Sayım Kalemi (XPO)")]
+    public class StockCountItem : XPObject
+    {
+        public StockCountItem(Session session) : base(session) { }
+
+        private StockCount _stockCount;
+        [Association("StockCount-CountItems")]
+        [Browsable(false)]
+        public StockCount StockCount { get => _stockCount; set => SetPropertyValue(nameof(StockCount), ref _stockCount, value); }
+
+        private Material _material;
+        [Association("Material-StockCountItems")]
+        [XafDisplayName("Malzeme")]
+        public Material Material {
+            get => _material;
+            set {
+                if(SetPropertyValue(nameof(Material), ref _material, value))
+                {
+                    if(!IsLoading && Material != null)
+                    {
+                        Unit = Material.BaseUnit;
+                        // Sistem miktarını burada da çekebiliriz, ama StockCount.LoadSystemQuantities daha toplu yapar.
+                    }
+                }
+            }
+        }
+
+        private double _systemQuantity;
+        [XafDisplayName("Sistem Miktarı")] // Sayım anındaki teorik miktar (Depo bazlı)
+        public double SystemQuantity { get => _systemQuantity; set => SetPropertyValue(nameof(SystemQuantity), ref _systemQuantity, value); }
+
+        private double _countedQuantity;
+        [XafDisplayName("Sayılan Miktar")]
+        public double CountedQuantity { get => _countedQuantity; set => SetPropertyValue(nameof(CountedQuantity), ref _countedQuantity, value); }
+
+        [PersistentAlias("CountedQuantity - SystemQuantity")]
+        [XafDisplayName("Fark")]
+        public double Difference => Convert.ToDouble(EvaluateAlias(nameof(Difference)));
+
+        private string _unit;
+        [XafDisplayName("Birim")]
+        public string Unit { get => _unit; set => SetPropertyValue(nameof(Unit), ref _unit, value); }
+
+        private bool _isAdjusted;
+        [XafDisplayName("Düzeltme Yapıldı")] // Fark stok hareketlerine yansıtıldı mı?
+        public bool IsAdjusted { get => _isAdjusted; set => SetPropertyValue(nameof(IsAdjusted), ref _isAdjusted, value); }
+
+        // Bu sayım farkı için oluşturulan stok hareketi (eğer varsa)
+        [Association("StockCountItem-StockTransaction"), Aggregated]
+        [XafDisplayName("Düzeltme Stok Hareketi")]
+        public StockTransaction AdjustmentStockTransaction {
+            get => GetPropertyValue<StockTransaction>(nameof(AdjustmentStockTransaction));
+            set => SetPropertyValue(nameof(AdjustmentStockTransaction), value);
+        }
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            CountedQuantity = 0;
+            IsAdjusted = false;
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/StockTransaction.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/StockTransaction.cs
@@ -1,0 +1,156 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Depo Yönetimi")]
+    [DisplayName("Stok Hareketi (XPO)")]
+    public class StockTransaction : XPObject
+    {
+        public StockTransaction(Session session) : base(session) { }
+
+        private DateTime _transactionDate;
+        [XafDisplayName("Hareket Tarihi")]
+        public DateTime TransactionDate
+        {
+            get => _transactionDate;
+            set => SetPropertyValue(nameof(TransactionDate), ref _transactionDate, value);
+        }
+
+        private Material _material;
+        [Association("Material-StockTransactions")]
+        [XafDisplayName("Malzeme/Ürün")]
+        public Material Material
+        {
+            get => _material;
+            set => SetPropertyValue(nameof(Material), ref _material, value);
+        }
+
+        private Warehouse _warehouse;
+        [Association("Warehouse-StockTransactions")]
+        [XafDisplayName("Depo")]
+        public Warehouse Warehouse
+        {
+            get => _warehouse;
+            set => SetPropertyValue(nameof(Warehouse), ref _warehouse, value);
+        }
+
+        private double _quantity;
+        [XafDisplayName("Miktar")] // Pozitif: Giriş, Negatif: Çıkış
+        public double Quantity
+        {
+            get => _quantity;
+            set {
+                if (SetPropertyValue(nameof(Quantity), ref _quantity, value))
+                {
+                    Material?.OnChanged(nameof(Material.TotalStockQuantity));
+                }
+            }
+        }
+
+        private string _unit;
+        [Size(50)]
+        [XafDisplayName("Birim")]
+        public string Unit
+        {
+            get => _unit;
+            set => SetPropertyValue(nameof(Unit), ref _unit, value);
+        }
+
+        private StockTransactionType _transactionType;
+        [XafDisplayName("Hareket Tipi")]
+        public StockTransactionType TransactionType
+        {
+            get => _transactionType;
+            set => SetPropertyValue(nameof(TransactionType), ref _transactionType, value);
+        }
+
+        private string _referenceDocumentNumber;
+        [XafDisplayName("İlişkili Belge No")]
+        public string ReferenceDocumentNumber
+        {
+            get => _referenceDocumentNumber;
+            set => SetPropertyValue(nameof(ReferenceDocumentNumber), ref _referenceDocumentNumber, value);
+        }
+
+        private PurchaseOrderItem _purchaseOrderItem;
+        [Association("PurchaseOrderItem-StockTransactions")]
+        [XafDisplayName("İlişkili Satınalma Sip. Kalemi")]
+        public PurchaseOrderItem PurchaseOrderItem
+        {
+            get => _purchaseOrderItem;
+            set => SetPropertyValue(nameof(PurchaseOrderItem), ref _purchaseOrderItem, value);
+        }
+
+        private ShipmentItem _shipmentItem;
+        [Association("ShipmentItem-StockTransactions")]
+        [XafDisplayName("İlişkili Sevkiyat Kalemi")]
+        public ShipmentItem ShipmentItem
+        {
+            get => _shipmentItem;
+            set => SetPropertyValue(nameof(ShipmentItem), ref _shipmentItem, value);
+        }
+
+        private ProductionOrder _productionOrderInbound; // Üretimden Giriş için
+        [Association("ProductionOrder-StockInbounds")]
+        [XafDisplayName("Üretim Emri (Giriş)")]
+        public ProductionOrder ProductionOrderInbound
+        {
+            get => _productionOrderInbound;
+            set => SetPropertyValue(nameof(ProductionOrderInbound), ref _productionOrderInbound, value);
+        }
+
+        private ProductionOrderMaterialRequirement _productionOrderOutboundMaterial; // Üretime Sarf için
+        [Association("ProductionOrderMaterialRequirement-StockOutbounds")]
+        [XafDisplayName("Üretim Malzeme İhtiyacı (Sarf)")]
+        public ProductionOrderMaterialRequirement ProductionOrderOutboundMaterial
+        {
+            get => _productionOrderOutboundMaterial;
+            set => SetPropertyValue(nameof(ProductionOrderOutboundMaterial), ref _productionOrderOutboundMaterial, value);
+        }
+
+        private StockCountItem _stockCountItem; // Sayım farkı için
+        [Association("StockCountItem-StockTransaction")]
+        [XafDisplayName("Stok Sayım Kalemi (Fark)")]
+        public StockCountItem StockCountItem
+        {
+            get => _stockCountItem;
+            set => SetPropertyValue(nameof(StockCountItem), ref _stockCountItem, value);
+        }
+
+
+        private string _description;
+        [XafDisplayName("Açıklama")]
+        public string Description
+        {
+            get => _description;
+            set => SetPropertyValue(nameof(Description), ref _description, value);
+        }
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            TransactionDate = DateTime.Now;
+        }
+    }
+
+    public enum StockTransactionType
+    {
+        [Display(Name = "Giriş (Satın Alma)")] PurchaseInbound = 0,
+        [Display(Name = "Çıkış (Satış/Sevkiyat)")] SalesOutbound = 1,
+        [Display(Name = "Giriş (Üretimden)")] ProductionInbound = 2,
+        [Display(Name = "Çıkış (Üretime Sarf)")] ProductionOutbound = 3,
+        [Display(Name = "Depolar Arası Transfer (Çıkış)")] TransferOutbound = 4,
+        [Display(Name = "Depolar Arası Transfer (Giriş)")] TransferInbound = 5,
+        [Display(Name = "Sayım Düzeltme (Artış)")] AdjustmentIncrease = 6,
+        [Display(Name = "Sayım Düzeltme (Azalış)")] AdjustmentDecrease = 7,
+        [Display(Name = "İade Girişi")] ReturnInbound = 8,
+        [Display(Name = "İade Çıkışı")] ReturnOutbound = 9,
+        [Display(Name = "Diğer Giriş")] OtherInbound = 10,
+        [Display(Name = "Diğer Çıkış")] OtherOutbound = 11
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Supplier.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Supplier.cs
@@ -1,0 +1,97 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+// using DevExpress.Persistent.Validation;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Satın Alma")]
+    [DisplayName("Tedarikçi (XPO)")]
+    public class Supplier : XPObject
+    {
+        public Supplier(Session session) : base(session) { }
+
+        private string _supplierCode;
+        [Size(20)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Tedarikçi Kodu")]
+        public string SupplierCode
+        {
+            get => _supplierCode;
+            set => SetPropertyValue(nameof(SupplierCode), ref _supplierCode, value);
+        }
+
+        private string _supplierName;
+        [Size(255)]
+        [XafDisplayName("Tedarikçi Adı")]
+        public string SupplierName
+        {
+            get => _supplierName;
+            set => SetPropertyValue(nameof(SupplierName), ref _supplierName, value);
+        }
+
+        private string _contactPerson;
+        [Size(100)]
+        [XafDisplayName("Yetkili Kişi")]
+        public string ContactPerson
+        {
+            get => _contactPerson;
+            set => SetPropertyValue(nameof(ContactPerson), ref _contactPerson, value);
+        }
+
+        private string _phoneNumber;
+        [Size(20)]
+        [XafDisplayName("Telefon")]
+        public string PhoneNumber
+        {
+            get => _phoneNumber;
+            set => SetPropertyValue(nameof(PhoneNumber), ref _phoneNumber, value);
+        }
+
+        private string _email;
+        [Size(100)]
+        [XafDisplayName("E-posta")]
+        public string Email
+        {
+            get => _email;
+            set => SetPropertyValue(nameof(Email), ref _email, value);
+        }
+
+        private string _address;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Adres")]
+        public string Address
+        {
+            get => _address;
+            set => SetPropertyValue(nameof(Address), ref _address, value);
+        }
+
+        private string _taxNumber;
+        [Size(11)]
+        [XafDisplayName("Vergi Numarası")]
+        public string TaxNumber
+        {
+            get => _taxNumber;
+            set => SetPropertyValue(nameof(TaxNumber), ref _taxNumber, value);
+        }
+
+        private string _notes;
+        [Size(SizeAttribute.Unlimited)]
+        [XafDisplayName("Notlar")]
+        public string Notes
+        {
+            get => _notes;
+            set => SetPropertyValue(nameof(Notes), ref _notes, value);
+        }
+
+        [Association("Supplier-PurchaseOrders")]
+        [XafDisplayName("Satınalma Siparişleri")]
+        public XPCollection<PurchaseOrder> PurchaseOrders => GetCollection<PurchaseOrder>(nameof(PurchaseOrders));
+
+        [Association("Supplier-Invoices")]
+        [XafDisplayName("Alış Faturaları")] // Supplier'a kesilen faturalar
+        public XPCollection<Invoice> Invoices => GetCollection<Invoice>(nameof(Invoices));
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/TimesheetEntry.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/TimesheetEntry.cs
@@ -1,0 +1,61 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System;
+using System.ComponentModel;
+using DevExpress.ExpressApp.Model; // ModelDefault için
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("İnsan Kaynakları")]
+    [DisplayName("Puantaj Kaydı (XPO)")]
+    public class TimesheetEntry : XPObject
+    {
+        public TimesheetEntry(Session session) : base(session) { }
+
+        private Employee _employee;
+        [Association("Employee-TimesheetEntries")]
+        [XafDisplayName("Personel")]
+        public Employee Employee { get => _employee; set => SetPropertyValue(nameof(Employee), ref _employee, value); }
+
+        private DateTime _entryDate;
+        [XafDisplayName("Tarih")]
+        public DateTime EntryDate { get => _entryDate; set => SetPropertyValue(nameof(EntryDate), ref _entryDate, value); }
+
+        private DateTime? _clockInTime;
+        [XafDisplayName("Giriş Saati")]
+        [ModelDefault("DisplayFormat", "{0:HH:mm}")]
+        [ModelDefault("EditMaskType", DevExpress.ExpressApp.Editors.EditMaskType.DateTime)] // EditMaskType
+        [ModelDefault("EditMask", "HH:mm")]
+        public DateTime? ClockInTime { get => _clockInTime; set => SetPropertyValue(nameof(ClockInTime), ref _clockInTime, value); }
+
+        private DateTime? _clockOutTime;
+        [XafDisplayName("Çıkış Saati")]
+        [ModelDefault("DisplayFormat", "{0:HH:mm}")]
+        [ModelDefault("EditMaskType", DevExpress.ExpressApp.Editors.EditMaskType.DateTime)] // EditMaskType
+        [ModelDefault("EditMask", "HH:mm")]
+        public DateTime? ClockOutTime { get => _clockOutTime; set => SetPropertyValue(nameof(ClockOutTime), ref _clockOutTime, value); }
+
+        // PersistentAlias ile saat farkını hesaplama
+        // Dikkat: ClockInTime ve ClockOutTime nullable olduğu için null kontrolü gerekir.
+        // XPO'da IIF ve IsNullOrEmpty gibi fonksiyonlar PersistentAlias içinde kullanılabilir.
+        [PersistentAlias("IIF(ClockOutTime Is Null Or ClockInTime Is Null, 0.0, TotalHours(ClockOutTime - ClockInTime))")]
+        [XafDisplayName("Çalışma Süresi (Saat)")]
+        public double HoursWorked => Convert.ToDouble(EvaluateAlias(nameof(HoursWorked)));
+
+        private double _overtimeHours;
+        [XafDisplayName("Mesai Süresi (Saat)")]
+        public double OvertimeHours { get => _overtimeHours; set => SetPropertyValue(nameof(OvertimeHours), ref _overtimeHours, value); }
+
+        private string _entryType; // Normal, Resmi Tatil, İzinli vb.
+        [XafDisplayName("Kayıt Tipi")]
+        public string EntryType { get => _entryType; set => SetPropertyValue(nameof(EntryType), ref _entryType, value); }
+
+        public override void AfterConstruction() {
+            base.AfterConstruction();
+            EntryType = "Normal";
+            EntryDate = DateTime.Today;
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Warehouse.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Warehouse.cs
@@ -1,0 +1,81 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Depo Yönetimi")]
+    [DisplayName("Depo (XPO)")]
+    public class Warehouse : XPObject
+    {
+        public Warehouse(Session session) : base(session) { }
+
+        private string _warehouseCode;
+        [Size(50)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("Depo Kodu")]
+        public string WarehouseCode
+        {
+            get => _warehouseCode;
+            set => SetPropertyValue(nameof(WarehouseCode), ref _warehouseCode, value);
+        }
+
+        private string _warehouseName;
+        [Size(255)]
+        [XafDisplayName("Depo Adı")]
+        public string WarehouseName
+        {
+            get => _warehouseName;
+            set => SetPropertyValue(nameof(WarehouseName), ref _warehouseName, value);
+        }
+
+        private string _address;
+        [XafDisplayName("Adres")]
+        public string Address
+        {
+            get => _address;
+            set => SetPropertyValue(nameof(Address), ref _address, value);
+        }
+
+        private string _responsiblePerson;
+        [XafDisplayName("Yetkili Kişi")]
+        public string ResponsiblePerson
+        {
+            get => _responsiblePerson;
+            set => SetPropertyValue(nameof(ResponsiblePerson), ref _responsiblePerson, value);
+        }
+
+        private bool _isActive;
+        [XafDisplayName("Aktif")]
+        public bool IsActive
+        {
+            get => _isActive;
+            set => SetPropertyValue(nameof(IsActive), ref _isActive, value);
+        }
+
+        [Association("Warehouse-StockTransactions")]
+        [XafDisplayName("Stok Hareketleri")]
+        public XPCollection<StockTransaction> StockTransactions => GetCollection<StockTransaction>(nameof(StockTransactions));
+
+        [Association("Warehouse-StockCounts")]
+        [XafDisplayName("Stok Sayımları")]
+        public XPCollection<StockCount> StockCounts => GetCollection<StockCount>(nameof(StockCounts));
+
+        [Association("Warehouse-ProductionOrderMaterialRequirements")] // Malzeme ihtiyaçlarının hangi depodan karşılanacağı
+        [XafDisplayName("Üretim Malzeme İhtiyaçları")]
+        public XPCollection<ProductionOrderMaterialRequirement> ProductionOrderMaterialRequirements => GetCollection<ProductionOrderMaterialRequirement>(nameof(ProductionOrderMaterialRequirements));
+
+        [Association("Warehouse-ShipmentItems")] // Sevkiyat kalemlerinin hangi depodan çıktığı
+        [XafDisplayName("Sevkiyat Kalemleri")]
+        public XPCollection<ShipmentItem> ShipmentItems => GetCollection<ShipmentItem>(nameof(ShipmentItems));
+
+
+        public override void AfterConstruction()
+        {
+            base.AfterConstruction();
+            IsActive = true;
+        }
+    }
+}

--- a/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Workstation.cs
+++ b/IsYonetimiUygulamasiXPO.Module/BusinessObjects/Workstation.cs
@@ -1,0 +1,69 @@
+using DevExpress.ExpressApp.DC;
+using DevExpress.Persistent.Base;
+using DevExpress.Xpo;
+using System.ComponentModel;
+
+namespace IsYonetimiUygulamasiXPO.Module.BusinessObjects
+{
+    [DefaultClassOptions]
+    [NavigationItem("Üretim Yönetimi")]
+    [DisplayName("İş İstasyonu (XPO)")]
+    public class Workstation : XPObject
+    {
+        public Workstation(Session session) : base(session) { }
+
+        private string _workstationCode;
+        [Size(50)]
+        [Indexed(Unique = true)]
+        [XafDisplayName("İş İstasyonu Kodu")]
+        public string WorkstationCode
+        {
+            get => _workstationCode;
+            set => SetPropertyValue(nameof(WorkstationCode), ref _workstationCode, value);
+        }
+
+        private string _workstationName;
+        [Size(255)]
+        [XafDisplayName("İş İstasyonu Adı")]
+        public string WorkstationName
+        {
+            get => _workstationName;
+            set => SetPropertyValue(nameof(WorkstationName), ref _workstationName, value);
+        }
+
+        private string _description;
+        [XafDisplayName("Açıklama")]
+        public string Description
+        {
+            get => _description;
+            set => SetPropertyValue(nameof(Description), ref _description, value);
+        }
+
+        private string _department;
+        [XafDisplayName("Departman")]
+        public string Department
+        {
+            get => _department;
+            set => SetPropertyValue(nameof(Department), ref _department, value);
+        }
+
+        private bool _isActive;
+        [XafDisplayName("Aktif")]
+        public bool IsActive
+        {
+            get => _isActive;
+            set => SetPropertyValue(nameof(IsActive), ref _isActive, value);
+        }
+
+        [Association("Workstation-RoutingOperations")]
+        [XafDisplayName("Rota Operasyonları")]
+        public XPCollection<RoutingOperation> RoutingOperations => GetCollection<RoutingOperation>(nameof(RoutingOperations));
+
+        [Association("Workstation-ProductionOrderOperationLogs")]
+        [XafDisplayName("Üretim Operasyon Kayıtları")]
+        public XPCollection<ProductionOrderOperationLog> ProductionOrderOperationLogs => GetCollection<ProductionOrderOperationLog>(nameof(ProductionOrderOperationLogs));
+
+
+        public override void AfterConstruction() { base.AfterConstruction(); IsActive = true; }
+    }
+}


### PR DESCRIPTION
This commit includes the XPO class definitions for all core business objects discussed, covering:
- CRM (Customer)
- Sales & Marketing (Lead, SalesOpportunity, Offer, OfferItem)
- Operations (Supplier, PurchaseOrder, PurchaseOrderItem, Warehouse, Material, StockTransaction, Shipment, ShipmentItem)
- Production & Manufacturing (Workstation, BillOfMaterials, BomItem, Routing, RoutingOperation, ProductionOrder, ProductionOrderMaterialRequirement, ProductionOrderOperationLog)
- Technical Service (Equipment, ServiceTicket, ServiceReport, MaintenancePlan, MaintenanceLog)
- Administrative & Supporting (Employee, LeaveRequest, TimesheetEntry, Invoice, InvoiceItem, FixedAsset, QualityCheck, NonConformance, Meeting (Event-derived), ServiceDefinition, ServiceContract, ServiceContractItem, StockCount, StockCountItem)

These definitions include basic properties, XPO attributes ([Size], [Indexed], [Association], [Aggregated], [PersistentAlias], [NonPersistent]), and AfterConstruction initializations.

Further work is needed for:
- Implementing robust auto-numbering ViewControllers (preferably using DistributedIdGeneratorHelper).
- Detailed business logic, calculations, and event handling within business objects or via separate ViewControllers.
- UI customizations and specific XAF module integrations (Validation, Reports, Scheduler, etc.).
- Comprehensive testing.

This commit provides the foundational XPO data model for the ERP application.